### PR TITLE
Add CAM-B3LYP refit files

### DIFF
--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-modsem-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-modsem-rfree.xml
@@ -1,0 +1,417 @@
+<?xml version="1.0" ?>
+<ForceField>
+<QUBEKit Version="2.1.1" Date="2022_03_03"/>
+<AtomTypes>
+<Type name="QUBE_0" class="0" element="F" mass="18.998"/>
+<Type name="QUBE_1" class="1" element="C" mass="12.011"/>
+<Type name="QUBE_2" class="2" element="F" mass="18.998"/>
+<Type name="QUBE_3" class="3" element="F" mass="18.998"/>
+<Type name="QUBE_4" class="4" element="C" mass="12.011"/>
+<Type name="QUBE_5" class="5" element="C" mass="12.011"/>
+<Type name="QUBE_6" class="6" element="C" mass="12.011"/>
+<Type name="QUBE_7" class="7" element="O" mass="15.999"/>
+<Type name="QUBE_8" class="8" element="O" mass="15.999"/>
+<Type name="QUBE_9" class="9" element="C" mass="12.011"/>
+<Type name="QUBE_10" class="10" element="C" mass="12.011"/>
+<Type name="QUBE_11" class="11" element="C" mass="12.011"/>
+<Type name="QUBE_12" class="12" element="C" mass="12.011"/>
+<Type name="QUBE_13" class="13" element="C" mass="12.011"/>
+<Type name="QUBE_14" class="14" element="N" mass="14.007"/>
+<Type name="QUBE_15" class="15" element="C" mass="12.011"/>
+<Type name="QUBE_16" class="16" element="C" mass="12.011"/>
+<Type name="QUBE_17" class="17" element="C" mass="12.011"/>
+<Type name="QUBE_18" class="18" element="C" mass="12.011"/>
+<Type name="QUBE_19" class="19" element="C" mass="12.011"/>
+<Type name="QUBE_20" class="20" element="C" mass="12.011"/>
+<Type name="QUBE_21" class="21" element="C" mass="12.011"/>
+<Type name="QUBE_22" class="22" element="H" mass="1.008"/>
+<Type name="QUBE_23" class="23" element="H" mass="1.008"/>
+<Type name="QUBE_24" class="24" element="H" mass="1.008"/>
+<Type name="QUBE_25" class="25" element="H" mass="1.008"/>
+<Type name="QUBE_26" class="26" element="H" mass="1.008"/>
+<Type name="QUBE_27" class="27" element="H" mass="1.008"/>
+<Type name="QUBE_28" class="28" element="H" mass="1.008"/>
+<Type name="QUBE_29" class="29" element="H" mass="1.008"/>
+<Type name="QUBE_30" class="30" element="H" mass="1.008"/>
+<Type name="QUBE_31" class="31" element="H" mass="1.008"/>
+<Type name="QUBE_32" class="32" element="H" mass="1.008"/>
+<Type name="QUBE_33" class="33" element="H" mass="1.008"/>
+<Type name="QUBE_34" class="34" element="H" mass="1.008"/>
+<Type name="QUBE_35" class="35" element="H" mass="1.008"/>
+</AtomTypes>
+<Residues>
+<Residue name="MOL">
+<Atom name="F1" type="QUBE_0"/>
+<Atom name="C1" type="QUBE_1"/>
+<Atom name="F2" type="QUBE_2"/>
+<Atom name="F3" type="QUBE_3"/>
+<Atom name="C2" type="QUBE_4"/>
+<Atom name="C3" type="QUBE_5"/>
+<Atom name="C4" type="QUBE_6"/>
+<Atom name="O1" type="QUBE_7"/>
+<Atom name="O2" type="QUBE_8"/>
+<Atom name="C5" type="QUBE_9"/>
+<Atom name="C6" type="QUBE_10"/>
+<Atom name="C7" type="QUBE_11"/>
+<Atom name="C8" type="QUBE_12"/>
+<Atom name="C9" type="QUBE_13"/>
+<Atom name="N1" type="QUBE_14"/>
+<Atom name="C10" type="QUBE_15"/>
+<Atom name="C11" type="QUBE_16"/>
+<Atom name="C12" type="QUBE_17"/>
+<Atom name="C13" type="QUBE_18"/>
+<Atom name="C14" type="QUBE_19"/>
+<Atom name="C15" type="QUBE_20"/>
+<Atom name="C16" type="QUBE_21"/>
+<Atom name="H1" type="QUBE_22"/>
+<Atom name="H2" type="QUBE_23"/>
+<Atom name="H3" type="QUBE_24"/>
+<Atom name="H4" type="QUBE_25"/>
+<Atom name="H5" type="QUBE_26"/>
+<Atom name="H6" type="QUBE_27"/>
+<Atom name="H7" type="QUBE_28"/>
+<Atom name="H8" type="QUBE_29"/>
+<Atom name="H9" type="QUBE_30"/>
+<Atom name="H10" type="QUBE_31"/>
+<Atom name="H11" type="QUBE_32"/>
+<Atom name="H12" type="QUBE_33"/>
+<Atom name="H13" type="QUBE_34"/>
+<Atom name="H14" type="QUBE_35"/>
+<Bond from="0" to="1"/>
+<Bond from="1" to="2"/>
+<Bond from="1" to="3"/>
+<Bond from="1" to="4"/>
+<Bond from="4" to="5"/>
+<Bond from="4" to="20"/>
+<Bond from="5" to="6"/>
+<Bond from="5" to="22"/>
+<Bond from="6" to="7"/>
+<Bond from="6" to="8"/>
+<Bond from="8" to="9"/>
+<Bond from="9" to="10"/>
+<Bond from="9" to="20"/>
+<Bond from="10" to="11"/>
+<Bond from="10" to="21"/>
+<Bond from="11" to="12"/>
+<Bond from="11" to="23"/>
+<Bond from="11" to="24"/>
+<Bond from="12" to="13"/>
+<Bond from="12" to="25"/>
+<Bond from="12" to="26"/>
+<Bond from="13" to="14"/>
+<Bond from="13" to="27"/>
+<Bond from="13" to="28"/>
+<Bond from="14" to="15"/>
+<Bond from="14" to="21"/>
+<Bond from="15" to="16"/>
+<Bond from="15" to="29"/>
+<Bond from="15" to="30"/>
+<Bond from="16" to="17"/>
+<Bond from="16" to="31"/>
+<Bond from="16" to="32"/>
+<Bond from="17" to="18"/>
+<Bond from="17" to="33"/>
+<Bond from="17" to="34"/>
+<Bond from="18" to="19"/>
+<Bond from="18" to="21"/>
+<Bond from="19" to="20"/>
+<Bond from="19" to="35"/>
+</Residue>
+</Residues>
+<HarmonicBondForce>
+<Bond length="0.13496011742992933" k="259586.48572299856" class1="0" class2="1"/>
+<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="2"/>
+<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="205802.9322041371" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="460185.44749956" class1="4" class2="5"/>
+<Bond length="0.14424155029894592" k="249691.30512503046" class1="4" class2="20"/>
+<Bond length="0.14564591082883707" k="229554.39047817126" class1="5" class2="6"/>
+<Bond length="0.10814511275621548" k="339079.2187655641" class1="5" class2="22"/>
+<Bond length="0.12065331189134901" k="705656.5336934443" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="215319.235157788" class1="6" class2="8"/>
+<Bond length="0.13688031490221975" k="258901.85615222016" class1="8" class2="9"/>
+<Bond length="0.13896874772055995" k="321973.43282597023" class1="9" class2="10"/>
+<Bond length="0.14002870254626093" k="295881.97483721166" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="199307.7600148271" class1="10" class2="11"/>
+<Bond length="0.14097123172598094" k="290372.52500279003" class1="10" class2="21"/>
+<Bond length="0.15240838998674713" k="198283.7633359121" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="295506.05426352075" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="295506.05426352075" class1="11" class2="24"/>
+<Bond length="0.151952792468063" k="201970.0217351758" class1="12" class2="13"/>
+<Bond length="0.10953626718429421" k="296694.52998631075" class1="12" class2="25"/>
+<Bond length="0.10953626718429421" k="296694.52998631075" class1="12" class2="26"/>
+<Bond length="0.14540752871782298" k="214895.31119640742" class1="13" class2="14"/>
+<Bond length="0.10989784615609387" k="286578.48647712264" class1="13" class2="27"/>
+<Bond length="0.10989784615609387" k="286578.48647712264" class1="13" class2="28"/>
+<Bond length="0.14539815451968735" k="215777.7380434388" class1="14" class2="15"/>
+<Bond length="0.1382504797109479" k="280264.52123681555" class1="14" class2="21"/>
+<Bond length="0.15197197918433356" k="202787.47629810506" class1="15" class2="16"/>
+<Bond length="0.10992030880021078" k="285946.38304967096" class1="15" class2="29"/>
+<Bond length="0.10992030880021078" k="285946.38304967096" class1="15" class2="30"/>
+<Bond length="0.1523393762132001" k="196415.7185398004" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="296569.2864479516" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="296569.2864479516" class1="16" class2="32"/>
+<Bond length="0.15125045314560476" k="203945.24729604847" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="292364.33657480346" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="292364.33657480346" class1="17" class2="34"/>
+<Bond length="0.13769965673158013" k="366734.9303769713" class1="18" class2="19"/>
+<Bond length="0.1423991064559355" k="261826.37957296983" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="307930.7671318767" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="326603.41920538543" class1="19" class2="35"/>
+</HarmonicBondForce>
+<HarmonicAngleForce>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
+<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="639.7476858128786" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="262.3563023615395" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="557.4746848468715" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="807.9095983882028" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="552.9254852453236" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="751.8116762302967" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
+<Angle k="718.830040433039" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="553.7538746695924" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="648.9592299042741" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
+<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="1121.6908591863469" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
+<Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="795.9032365496385" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
+<Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="1061.3339489822274" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
+<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
+<Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="27"/>
+<Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="28"/>
+<Angle k="1043.2371059142824" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
+<Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="29"/>
+<Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="30"/>
+<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
+<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
+<Angle k="1017.6871864118357" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
+<Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="1173.139818868356" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
+<Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
+<Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="700.965705603468" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="282.6287693615428" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
+<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="264.5571241818087" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
+<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
+<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
+<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+</HarmonicAngleForce>
+<PeriodicTorsionForce ordering="smirnoff">
+<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+</PeriodicTorsionForce>
+<NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
+<Atom charge="-0.25233" epsilon="0.26146577464789816" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="0.776573" epsilon="0.2732087688406762" sigma="0.3089811804362698" type="QUBE_1"/>
+<Atom charge="-0.242744" epsilon="0.2601425350261072" sigma="0.29666886791766617" type="QUBE_2"/>
+<Atom charge="-0.251133" epsilon="0.2614064687902009" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.051181" epsilon="0.3114224736729138" sigma="0.34366343352476914" type="QUBE_4"/>
+<Atom charge="-0.303105" epsilon="0.32369222426161337" sigma="0.3546262114386765" type="QUBE_5"/>
+<Atom charge="0.667684" epsilon="0.273086823211064" sigma="0.3088691064321672" type="QUBE_6"/>
+<Atom charge="-0.56416" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
+<Atom charge="-0.266561" epsilon="0.6874490135799819" sigma="0.27383444348429714" type="QUBE_8"/>
+<Atom charge="0.227775" epsilon="0.2970905744228003" sigma="0.33075499678354847" type="QUBE_9"/>
+<Atom charge="-0.120378" epsilon="0.3152955026616835" sigma="0.34713250572596427" type="QUBE_10"/>
+<Atom charge="-0.150389" epsilon="0.3156773512728494" sigma="0.34747409368437077" type="QUBE_11"/>
+<Atom charge="-0.159758" epsilon="0.3123315926020616" sigma="0.3444784539612102" type="QUBE_12"/>
+<Atom charge="-0.024505" epsilon="0.30560536129474425" sigma="0.3384377994854968" type="QUBE_13"/>
+<Atom charge="-0.157381" epsilon="0.4531616292807186" sigma="0.31284205533862425" type="QUBE_14"/>
+<Atom charge="-0.024064" epsilon="0.3055800820915715" sigma="0.33841505020165746" type="QUBE_15"/>
+<Atom charge="-0.166073" epsilon="0.31320671947642564" sigma="0.34526258086814143" type="QUBE_16"/>
+<Atom charge="-0.157372" epsilon="0.31411478528043374" sigma="0.34607578766241137" type="QUBE_17"/>
+<Atom charge="0.000334" epsilon="0.3081374258338789" sigma="0.34071467656087057" type="QUBE_18"/>
+<Atom charge="-0.167065" epsilon="0.32462657455115507" sigma="0.3554578105980868" type="QUBE_19"/>
+<Atom charge="-0.078422" epsilon="0.3156767824810448" sigma="0.3474735849213942" type="QUBE_20"/>
+<Atom charge="0.155012" epsilon="0.30132283520205017" sigma="0.3345788062188248" type="QUBE_21"/>
+<Atom charge="0.167521" epsilon="0.0978107710473215" sigma="0.23811289791476886" type="QUBE_22"/>
+<Atom charge="0.097355" epsilon="0.10056024578458915" sigma="0.24353785483009005" type="QUBE_23"/>
+<Atom charge="0.090775" epsilon="0.1012671279779549" sigma="0.24492807935732094" type="QUBE_24"/>
+<Atom charge="0.091394" epsilon="0.10002118610996971" sigma="0.24247645596416315" type="QUBE_25"/>
+<Atom charge="0.095147" epsilon="0.09768974390991514" sigma="0.2378734492279842" type="QUBE_26"/>
+<Atom charge="0.078988" epsilon="0.10050647116630629" sigma="0.24343202152984458" type="QUBE_27"/>
+<Atom charge="0.061498" epsilon="0.10369430117364004" sigma="0.24968785757653836" type="QUBE_28"/>
+<Atom charge="0.079282" epsilon="0.10037122656954406" sigma="0.24316580104266824" type="QUBE_29"/>
+<Atom charge="0.06061" epsilon="0.1036603620040513" sigma="0.2496214465559107" type="QUBE_30"/>
+<Atom charge="0.093159" epsilon="0.1001076810033671" sigma="0.24264683492102518" type="QUBE_31"/>
+<Atom charge="0.096345" epsilon="0.09777800648277413" sigma="0.23804807965605482" type="QUBE_32"/>
+<Atom charge="0.096629" epsilon="0.09882519092751813" sigma="0.24011772344082505" type="QUBE_33"/>
+<Atom charge="0.087509" epsilon="0.1010563421031184" sigma="0.24451371781920664" type="QUBE_34"/>
+<Atom charge="0.113031" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
+</NonbondedForce>
+</ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-qcforce-ub-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-qcforce-ub-rfree.xml
@@ -1,0 +1,475 @@
+<?xml version="1.0" ?>
+<ForceField>
+<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<AtomTypes>
+<Type name="QUBE_0" class="0" element="F" mass="18.998"/>
+<Type name="QUBE_1" class="1" element="C" mass="12.011"/>
+<Type name="QUBE_2" class="2" element="F" mass="18.998"/>
+<Type name="QUBE_3" class="3" element="F" mass="18.998"/>
+<Type name="QUBE_4" class="4" element="C" mass="12.011"/>
+<Type name="QUBE_5" class="5" element="C" mass="12.011"/>
+<Type name="QUBE_6" class="6" element="C" mass="12.011"/>
+<Type name="QUBE_7" class="7" element="O" mass="15.999"/>
+<Type name="QUBE_8" class="8" element="O" mass="15.999"/>
+<Type name="QUBE_9" class="9" element="C" mass="12.011"/>
+<Type name="QUBE_10" class="10" element="C" mass="12.011"/>
+<Type name="QUBE_11" class="11" element="C" mass="12.011"/>
+<Type name="QUBE_12" class="12" element="C" mass="12.011"/>
+<Type name="QUBE_13" class="13" element="C" mass="12.011"/>
+<Type name="QUBE_14" class="14" element="N" mass="14.007"/>
+<Type name="QUBE_15" class="15" element="C" mass="12.011"/>
+<Type name="QUBE_16" class="16" element="C" mass="12.011"/>
+<Type name="QUBE_17" class="17" element="C" mass="12.011"/>
+<Type name="QUBE_18" class="18" element="C" mass="12.011"/>
+<Type name="QUBE_19" class="19" element="C" mass="12.011"/>
+<Type name="QUBE_20" class="20" element="C" mass="12.011"/>
+<Type name="QUBE_21" class="21" element="C" mass="12.011"/>
+<Type name="QUBE_22" class="22" element="H" mass="1.008"/>
+<Type name="QUBE_23" class="23" element="H" mass="1.008"/>
+<Type name="QUBE_24" class="24" element="H" mass="1.008"/>
+<Type name="QUBE_25" class="25" element="H" mass="1.008"/>
+<Type name="QUBE_26" class="26" element="H" mass="1.008"/>
+<Type name="QUBE_27" class="27" element="H" mass="1.008"/>
+<Type name="QUBE_28" class="28" element="H" mass="1.008"/>
+<Type name="QUBE_29" class="29" element="H" mass="1.008"/>
+<Type name="QUBE_30" class="30" element="H" mass="1.008"/>
+<Type name="QUBE_31" class="31" element="H" mass="1.008"/>
+<Type name="QUBE_32" class="32" element="H" mass="1.008"/>
+<Type name="QUBE_33" class="33" element="H" mass="1.008"/>
+<Type name="QUBE_34" class="34" element="H" mass="1.008"/>
+<Type name="QUBE_35" class="35" element="H" mass="1.008"/>
+</AtomTypes>
+<Residues>
+<Residue name="MOL">
+<Atom name="F1" type="QUBE_0"/>
+<Atom name="C1" type="QUBE_1"/>
+<Atom name="F2" type="QUBE_2"/>
+<Atom name="F3" type="QUBE_3"/>
+<Atom name="C2" type="QUBE_4"/>
+<Atom name="C3" type="QUBE_5"/>
+<Atom name="C4" type="QUBE_6"/>
+<Atom name="O1" type="QUBE_7"/>
+<Atom name="O2" type="QUBE_8"/>
+<Atom name="C5" type="QUBE_9"/>
+<Atom name="C6" type="QUBE_10"/>
+<Atom name="C7" type="QUBE_11"/>
+<Atom name="C8" type="QUBE_12"/>
+<Atom name="C9" type="QUBE_13"/>
+<Atom name="N1" type="QUBE_14"/>
+<Atom name="C10" type="QUBE_15"/>
+<Atom name="C11" type="QUBE_16"/>
+<Atom name="C12" type="QUBE_17"/>
+<Atom name="C13" type="QUBE_18"/>
+<Atom name="C14" type="QUBE_19"/>
+<Atom name="C15" type="QUBE_20"/>
+<Atom name="C16" type="QUBE_21"/>
+<Atom name="H1" type="QUBE_22"/>
+<Atom name="H2" type="QUBE_23"/>
+<Atom name="H3" type="QUBE_24"/>
+<Atom name="H4" type="QUBE_25"/>
+<Atom name="H5" type="QUBE_26"/>
+<Atom name="H6" type="QUBE_27"/>
+<Atom name="H7" type="QUBE_28"/>
+<Atom name="H8" type="QUBE_29"/>
+<Atom name="H9" type="QUBE_30"/>
+<Atom name="H10" type="QUBE_31"/>
+<Atom name="H11" type="QUBE_32"/>
+<Atom name="H12" type="QUBE_33"/>
+<Atom name="H13" type="QUBE_34"/>
+<Atom name="H14" type="QUBE_35"/>
+<Bond from="0" to="1"/>
+<Bond from="1" to="2"/>
+<Bond from="1" to="3"/>
+<Bond from="1" to="4"/>
+<Bond from="4" to="5"/>
+<Bond from="4" to="20"/>
+<Bond from="5" to="6"/>
+<Bond from="5" to="22"/>
+<Bond from="6" to="7"/>
+<Bond from="6" to="8"/>
+<Bond from="8" to="9"/>
+<Bond from="9" to="10"/>
+<Bond from="9" to="20"/>
+<Bond from="10" to="11"/>
+<Bond from="10" to="21"/>
+<Bond from="11" to="12"/>
+<Bond from="11" to="23"/>
+<Bond from="11" to="24"/>
+<Bond from="12" to="13"/>
+<Bond from="12" to="25"/>
+<Bond from="12" to="26"/>
+<Bond from="13" to="14"/>
+<Bond from="13" to="27"/>
+<Bond from="13" to="28"/>
+<Bond from="14" to="15"/>
+<Bond from="14" to="21"/>
+<Bond from="15" to="16"/>
+<Bond from="15" to="29"/>
+<Bond from="15" to="30"/>
+<Bond from="16" to="17"/>
+<Bond from="16" to="31"/>
+<Bond from="16" to="32"/>
+<Bond from="17" to="18"/>
+<Bond from="17" to="33"/>
+<Bond from="17" to="34"/>
+<Bond from="18" to="19"/>
+<Bond from="18" to="21"/>
+<Bond from="19" to="20"/>
+<Bond from="19" to="35"/>
+<Bond from="0" to="2"/>
+<Bond from="0" to="3"/>
+<Bond from="0" to="4"/>
+<Bond from="1" to="5"/>
+<Bond from="1" to="20"/>
+<Bond from="2" to="3"/>
+<Bond from="2" to="4"/>
+<Bond from="3" to="4"/>
+<Bond from="4" to="6"/>
+<Bond from="4" to="22"/>
+<Bond from="4" to="9"/>
+<Bond from="4" to="19"/>
+<Bond from="5" to="20"/>
+<Bond from="5" to="7"/>
+<Bond from="5" to="8"/>
+<Bond from="6" to="22"/>
+<Bond from="6" to="9"/>
+<Bond from="7" to="8"/>
+<Bond from="8" to="10"/>
+<Bond from="8" to="20"/>
+<Bond from="9" to="11"/>
+<Bond from="9" to="21"/>
+<Bond from="9" to="19"/>
+<Bond from="10" to="20"/>
+<Bond from="10" to="12"/>
+<Bond from="10" to="23"/>
+<Bond from="10" to="24"/>
+<Bond from="10" to="14"/>
+<Bond from="10" to="18"/>
+<Bond from="11" to="21"/>
+<Bond from="11" to="13"/>
+<Bond from="11" to="25"/>
+<Bond from="11" to="26"/>
+<Bond from="12" to="23"/>
+<Bond from="12" to="24"/>
+<Bond from="12" to="14"/>
+<Bond from="12" to="27"/>
+<Bond from="12" to="28"/>
+<Bond from="13" to="25"/>
+<Bond from="13" to="26"/>
+<Bond from="13" to="15"/>
+<Bond from="13" to="21"/>
+<Bond from="14" to="27"/>
+<Bond from="14" to="28"/>
+<Bond from="14" to="16"/>
+<Bond from="14" to="29"/>
+<Bond from="14" to="30"/>
+<Bond from="14" to="18"/>
+<Bond from="15" to="21"/>
+<Bond from="15" to="17"/>
+<Bond from="15" to="31"/>
+<Bond from="15" to="32"/>
+<Bond from="16" to="29"/>
+<Bond from="16" to="30"/>
+<Bond from="16" to="18"/>
+<Bond from="16" to="33"/>
+<Bond from="16" to="34"/>
+<Bond from="17" to="31"/>
+<Bond from="17" to="32"/>
+<Bond from="17" to="19"/>
+<Bond from="17" to="21"/>
+<Bond from="18" to="33"/>
+<Bond from="18" to="34"/>
+<Bond from="18" to="20"/>
+<Bond from="18" to="35"/>
+<Bond from="19" to="21"/>
+<Bond from="20" to="35"/>
+<Bond from="23" to="24"/>
+<Bond from="25" to="26"/>
+<Bond from="27" to="28"/>
+<Bond from="29" to="30"/>
+<Bond from="31" to="32"/>
+<Bond from="33" to="34"/>
+</Residue>
+</Residues>
+<HarmonicBondForce>
+<Bond length="0.13469356407442745" k="248696.12934885127" class1="0" class2="1"/>
+<Bond length="0.13469356407442745" k="248696.12934885127" class1="1" class2="2"/>
+<Bond length="0.13469356407442745" k="248696.12934885127" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="218544.0885900748" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="452409.97449639573" class1="4" class2="5"/>
+<Bond length="0.14424155029894592" k="235616.92931297317" class1="4" class2="20"/>
+<Bond length="0.14564591082883707" k="213431.4378351508" class1="5" class2="6"/>
+<Bond length="0.10814511275621548" k="336932.01010267145" class1="5" class2="22"/>
+<Bond length="0.12065331189134901" k="697056.894846477" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="171032.87641743006" class1="6" class2="8"/>
+<Bond length="0.13688031490221975" k="245764.7620565325" class1="8" class2="9"/>
+<Bond length="0.13896874772055995" k="301499.83087445924" class1="9" class2="10"/>
+<Bond length="0.14002870254626093" k="278597.1473880633" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="197686.8752677544" class1="10" class2="11"/>
+<Bond length="0.14097123172598094" k="266870.6670559599" class1="10" class2="21"/>
+<Bond length="0.15240838998674713" k="188853.87239804704" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="298213.74000018986" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="298213.74000018986" class1="11" class2="24"/>
+<Bond length="0.15195279246806304" k="190828.67966440998" class1="12" class2="13"/>
+<Bond length="0.1095362671842942" k="299378.38173584116" class1="12" class2="25"/>
+<Bond length="0.1095362671842942" k="299378.38173584116" class1="12" class2="26"/>
+<Bond length="0.14540284161875516" k="204754.08956276052" class1="13" class2="14"/>
+<Bond length="0.10990907747815233" k="289809.04755993414" class1="13" class2="27"/>
+<Bond length="0.10990907747815233" k="289809.04755993414" class1="13" class2="28"/>
+<Bond length="0.14540284161875516" k="204754.08956276052" class1="14" class2="15"/>
+<Bond length="0.1382504797109479" k="275055.1221468047" class1="14" class2="21"/>
+<Bond length="0.15197197918433358" k="190569.04382625862" class1="15" class2="16"/>
+<Bond length="0.10990907747815233" k="289809.04755993414" class1="15" class2="29"/>
+<Bond length="0.10990907747815233" k="289809.04755993414" class1="15" class2="30"/>
+<Bond length="0.15233937621320012" k="188400.8899591935" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="299020.7928388245" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="299020.7928388245" class1="16" class2="32"/>
+<Bond length="0.15125045314560479" k="200506.13850190217" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="295027.9665962813" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="295027.9665962813" class1="17" class2="34"/>
+<Bond length="0.13769965673158013" k="349377.2659826007" class1="18" class2="19"/>
+<Bond length="0.14239910645593554" k="236685.3977535236" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="290384.285293299" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="332068.7475784242" class1="19" class2="35"/>
+<Bond length="0.21652967675118645" k="65815.81802630179" class1="0" class2="2"/>
+<Bond length="0.21652967675118645" k="65815.81802630179" class1="0" class2="3"/>
+<Bond length="0.2367308754593913" k="34649.92669158233" class1="0" class2="4"/>
+<Bond length="0.24637183735463966" k="22668.12122489944" class1="1" class2="5"/>
+<Bond length="0.2552484693842637" k="33041.46692529321" class1="1" class2="20"/>
+<Bond length="0.21652967675118645" k="65815.81802630179" class1="2" class2="3"/>
+<Bond length="0.2367308754593913" k="34649.92669158233" class1="2" class2="4"/>
+<Bond length="0.2367308754593913" k="34649.92669158233" class1="3" class2="4"/>
+<Bond length="0.24424950724834102" k="33454.2998491019" class1="4" class2="6"/>
+<Bond length="0.2137728474468069" k="14245.085810712015" class1="4" class2="22"/>
+<Bond length="0.24235320460628298" k="29235.77324721258" class1="4" class2="9"/>
+<Bond length="0.25380961300478017" k="38071.000612605276" class1="4" class2="19"/>
+<Bond length="0.24317848563613786" k="48937.59397074284" class1="5" class2="20"/>
+<Bond length="0.23691569131052775" k="62517.08343169539" class1="5" class2="7"/>
+<Bond length="0.2404062775308595" k="35515.642919775084" class1="5" class2="8"/>
+<Bond length="0.21616921612132547" k="16817.64582074077" class1="6" class2="22"/>
+<Bond length="0.24155207989996136" k="43514.91376185767" class1="6" class2="9"/>
+<Bond length="0.22173066563125332" k="94829.60574869142" class1="7" class2="8"/>
+<Bond length="0.23348443062234248" k="57621.033943389804" class1="8" class2="10"/>
+<Bond length="0.2409996256628092" k="33101.49253486298" class1="8" class2="20"/>
+<Bond length="0.2508615762103375" k="19476.432640405463" class1="9" class2="11"/>
+<Bond length="0.2403603662334068" k="49292.67773448853" class1="9" class2="21"/>
+<Bond length="0.23893622663484204" k="44594.43403948841" class1="9" class2="19"/>
+<Bond length="0.24561151969819398" k="39645.792636160666" class1="10" class2="20"/>
+<Bond length="0.25043517668197823" k="20362.7363655314" class1="10" class2="12"/>
+<Bond length="0.2143215696888813" k="17514.030354806964" class1="10" class2="23"/>
+<Bond length="0.2143215696888813" k="17514.030354806964" class1="10" class2="24"/>
+<Bond length="0.24191336629679144" k="47149.986141393405" class1="10" class2="14"/>
+<Bond length="0.2449311721801657" k="41833.34357064601" class1="10" class2="18"/>
+<Bond length="0.2554238649411517" k="15110.572323934382" class1="11" class2="21"/>
+<Bond length="0.24943515144206752" k="31166.724741526126" class1="11" class2="13"/>
+<Bond length="0.21638649819857225" k="11482.814271086178" class1="11" class2="25"/>
+<Bond length="0.21638649819857225" k="11482.814271086178" class1="11" class2="26"/>
+<Bond length="0.21637698760602225" k="11875.34822029003" class1="12" class2="23"/>
+<Bond length="0.21637698760602225" k="11875.34822029003" class1="12" class2="24"/>
+<Bond length="0.2445664336412628" k="32697.295592576887" class1="12" class2="14"/>
+<Bond length="0.21627463620927637" k="11582.775159333945" class1="12" class2="27"/>
+<Bond length="0.21627463620927637" k="11582.775159333945" class1="12" class2="28"/>
+<Bond length="0.2146925734975977" k="13456.42635345173" class1="13" class2="25"/>
+<Bond length="0.2146925734975977" k="13456.42635345173" class1="13" class2="26"/>
+<Bond length="0.2466018129470507" k="3645.036085047076" class1="13" class2="15"/>
+<Bond length="0.24530456727951677" k="25381.47463105833" class1="13" class2="21"/>
+<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="27"/>
+<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="28"/>
+<Bond length="0.24506286921679699" k="32714.429307871946" class1="14" class2="16"/>
+<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="29"/>
+<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="30"/>
+<Bond length="0.24341685186846426" k="45704.36250778908" class1="14" class2="18"/>
+<Bond length="0.24530456727951677" k="25381.47463105833" class1="15" class2="21"/>
+<Bond length="0.2482899688867673" k="30243.829665329897" class1="15" class2="17"/>
+<Bond length="0.21482896649717576" k="13727.239961651174" class1="15" class2="31"/>
+<Bond length="0.21482896649717576" k="13727.239961651174" class1="15" class2="32"/>
+<Bond length="0.2161210191868845" k="10803.416482315797" class1="16" class2="29"/>
+<Bond length="0.2161210191868845" k="10803.416482315797" class1="16" class2="30"/>
+<Bond length="0.25071186281720664" k="20777.32383702234" class1="16" class2="18"/>
+<Bond length="0.21588768954068127" k="12426.545442223944" class1="16" class2="33"/>
+<Bond length="0.21588768954068127" k="12426.545442223944" class1="16" class2="34"/>
+<Bond length="0.2166014429827969" k="11766.726405139507" class1="17" class2="31"/>
+<Bond length="0.2166014429827969" k="11766.726405139507" class1="17" class2="32"/>
+<Bond length="0.2501622513015905" k="13594.569383728967" class1="17" class2="19"/>
+<Bond length="0.25504206857818595" k="16625.350647412968" class1="17" class2="21"/>
+<Bond length="0.2145767289449851" k="14970.96386176797" class1="18" class2="33"/>
+<Bond length="0.2145767289449851" k="14970.96386176797" class1="18" class2="34"/>
+<Bond length="0.24352193235081798" k="52118.294889790704" class1="18" class2="20"/>
+<Bond length="0.21177124922411472" k="7990.287381239743" class1="18" class2="35"/>
+<Bond length="0.24207073997933107" k="52699.921136539124" class1="19" class2="21"/>
+<Bond length="0.21560948327565438" k="10649.532635033214" class1="20" class2="35"/>
+<Bond length="0.17462080461979723" k="13731.15742367687" class1="23" class2="24"/>
+<Bond length="0.17661650584198943" k="13427.247612635645" class1="25" class2="26"/>
+<Bond length="0.17685797959042412" k="13157.926302512604" class1="27" class2="28"/>
+<Bond length="0.17685797959042412" k="13157.926302512604" class1="29" class2="30"/>
+<Bond length="0.1767871797367549" k="13264.20081532144" class1="31" class2="32"/>
+<Bond length="0.17560269028929812" k="13781.081713223526" class1="33" class2="34"/>
+</HarmonicBondForce>
+<HarmonicAngleForce>
+<Angle k="634.9590563926183" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
+<Angle k="634.9590563926183" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
+<Angle k="531.6283246477715" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
+<Angle k="412.2136427606707" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="135.54119603796627" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="634.9590563926183" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="531.6283246477715" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
+<Angle k="531.6283246477715" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="587.6431955844229" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="246.56202758152673" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="546.1164982034062" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="678.8281698124405" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="98.1305991319774" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="249.07204008402334" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="110.74533271318298" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="213.61856334435936" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="478.1225794840239" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="769.3256680451444" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="660.1215176306495" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
+<Angle k="431.47694830279323" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="317.636853594348" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="395.23989766599817" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
+<Angle k="304.4342257281013" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="100.97743152622468" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="400.6374482905871" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
+<Angle k="296.6240561074525" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="296.6240561074525" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="597.6626799748337" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="105.72056959700619" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="417.8642188947819" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="602.3931784157377" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="354.7074021223168" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
+<Angle k="354.7074021223168" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
+<Angle k="347.97195187859677" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="347.97195187859677" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="518.3047196834742" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="351.845036413452" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="351.845036413452" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="342.61733009725106" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
+<Angle k="342.61733009725106" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
+<Angle k="626.6335617498364" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="332.3549732351152" angle="2.0891509949808236" class1="13" class2="14" class3="21"/>
+<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
+<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
+<Angle k="510.6224013201775" angle="1.9368432495236967" class1="14" class2="15" class3="16"/>
+<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
+<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
+<Angle k="615.3944381689575" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
+<Angle k="332.3549732351152" angle="2.0891509949808236" class1="15" class2="14" class3="21"/>
+<Angle k="612.9457825256006" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="343.6090714215259" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
+<Angle k="343.6090714215259" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
+<Angle k="358.2972870917604" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="358.2972870917604" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="372.21383486807724" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
+<Angle k="353.09489772399587" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="353.09489772399587" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="361.5328323378854" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="361.5328323378854" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="540.4710511015742" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="414.9682578497672" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="299.28391787230015" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
+<Angle k="299.28391787230015" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="219.76942365478908" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="325.34270240972637" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
+<Angle k="371.7109226596257" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="190.2700655022649" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="261.8215738578441" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
+<Angle k="270.01472283443877" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="260.09441925250667" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
+<Angle k="260.09441925250667" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
+<Angle k="266.4399402887101" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="273.1212697604543" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+</HarmonicAngleForce>
+<PeriodicTorsionForce ordering="charmm">
+<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="15.473463227808722" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="24.563640891914183" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="13.954774388128113" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="62.76603413970627" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="43.133777465195095" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="13.974735215324651" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0" k2="32.18167917496398" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0" k2="20.07872661956894" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="6.104857592585052" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="21.553695299112583" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="7.522756764653054" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="10.980117363726146" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.686367153974892" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="35.83233697287645" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="13.21799676515167" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.855561721123287" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="27.04023902529637" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="19.986760642803024" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="13.319307598582146" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="19.378021510853664" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="21.94926717207507" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="10.788588345160615" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="5.078542475508571" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="6.143392431427742" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0" k2="37.75627559250844" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="36.41427607021837" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="25.634665243843635" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0" k2="17.570887319483386" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="26.671876584664247" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="4.546919066371498" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0" k2="22.783833553150686" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="21.61765933035253" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="2.824280464463056" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="23.05852443664049" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="20.226958971463848" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="21.660701605400497" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="3.5740794609122" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0" k2="28.80048878534939" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+</PeriodicTorsionForce>
+<RBTorsionForce>
+<Proper c0="19.515" c1="56.0" c2="40.173" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.431" c1="83.552" c2="81.435" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="20.886" c1="80.774" c2="78.098" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="17.459" c1="54.14" c2="41.972" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
+</RBTorsionForce>
+<NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
+<Atom charge="-0.25233" epsilon="0.26146577464789816" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="0.776573" epsilon="0.2732087688406762" sigma="0.3089811804362698" type="QUBE_1"/>
+<Atom charge="-0.242744" epsilon="0.2601425350261072" sigma="0.29666886791766617" type="QUBE_2"/>
+<Atom charge="-0.251133" epsilon="0.2614064687902009" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.051181" epsilon="0.3114224736729138" sigma="0.34366343352476914" type="QUBE_4"/>
+<Atom charge="-0.303105" epsilon="0.32369222426161337" sigma="0.3546262114386765" type="QUBE_5"/>
+<Atom charge="0.667684" epsilon="0.273086823211064" sigma="0.3088691064321672" type="QUBE_6"/>
+<Atom charge="-0.56416" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
+<Atom charge="-0.266561" epsilon="0.6874490135799819" sigma="0.27383444348429714" type="QUBE_8"/>
+<Atom charge="0.227775" epsilon="0.2970905744228003" sigma="0.33075499678354847" type="QUBE_9"/>
+<Atom charge="-0.120378" epsilon="0.3152955026616835" sigma="0.34713250572596427" type="QUBE_10"/>
+<Atom charge="-0.150389" epsilon="0.3156773512728494" sigma="0.34747409368437077" type="QUBE_11"/>
+<Atom charge="-0.159758" epsilon="0.3123315926020616" sigma="0.3444784539612102" type="QUBE_12"/>
+<Atom charge="-0.024505" epsilon="0.30560536129474425" sigma="0.3384377994854968" type="QUBE_13"/>
+<Atom charge="-0.157381" epsilon="0.4531616292807186" sigma="0.31284205533862425" type="QUBE_14"/>
+<Atom charge="-0.024064" epsilon="0.3055800820915715" sigma="0.33841505020165746" type="QUBE_15"/>
+<Atom charge="-0.166073" epsilon="0.31320671947642564" sigma="0.34526258086814143" type="QUBE_16"/>
+<Atom charge="-0.157372" epsilon="0.31411478528043374" sigma="0.34607578766241137" type="QUBE_17"/>
+<Atom charge="0.000334" epsilon="0.3081374258338789" sigma="0.34071467656087057" type="QUBE_18"/>
+<Atom charge="-0.167065" epsilon="0.32462657455115507" sigma="0.3554578105980868" type="QUBE_19"/>
+<Atom charge="-0.078422" epsilon="0.3156767824810448" sigma="0.3474735849213942" type="QUBE_20"/>
+<Atom charge="0.155012" epsilon="0.30132283520205017" sigma="0.3345788062188248" type="QUBE_21"/>
+<Atom charge="0.167521" epsilon="0.0978107710473215" sigma="0.23811289791476886" type="QUBE_22"/>
+<Atom charge="0.097355" epsilon="0.10056024578458915" sigma="0.24353785483009005" type="QUBE_23"/>
+<Atom charge="0.090775" epsilon="0.1012671279779549" sigma="0.24492807935732094" type="QUBE_24"/>
+<Atom charge="0.091394" epsilon="0.10002118610996971" sigma="0.24247645596416315" type="QUBE_25"/>
+<Atom charge="0.095147" epsilon="0.09768974390991514" sigma="0.2378734492279842" type="QUBE_26"/>
+<Atom charge="0.078988" epsilon="0.10050647116630629" sigma="0.24343202152984458" type="QUBE_27"/>
+<Atom charge="0.061498" epsilon="0.10369430117364004" sigma="0.24968785757653836" type="QUBE_28"/>
+<Atom charge="0.079282" epsilon="0.10037122656954406" sigma="0.24316580104266824" type="QUBE_29"/>
+<Atom charge="0.06061" epsilon="0.1036603620040513" sigma="0.2496214465559107" type="QUBE_30"/>
+<Atom charge="0.093159" epsilon="0.1001076810033671" sigma="0.24264683492102518" type="QUBE_31"/>
+<Atom charge="0.096345" epsilon="0.09777800648277413" sigma="0.23804807965605482" type="QUBE_32"/>
+<Atom charge="0.096629" epsilon="0.09882519092751813" sigma="0.24011772344082505" type="QUBE_33"/>
+<Atom charge="0.087509" epsilon="0.1010563421031184" sigma="0.24451371781920664" type="QUBE_34"/>
+<Atom charge="0.113031" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
+</NonbondedForce>
+</ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-modsem-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-modsem-rfree.xml
@@ -1,0 +1,425 @@
+<?xml version="1.0" ?>
+<ForceField>
+<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<AtomTypes>
+<Type name="QUBE_0" class="0" element="F" mass="18.998"/>
+<Type name="QUBE_1" class="1" element="C" mass="12.011"/>
+<Type name="QUBE_2" class="2" element="F" mass="18.998"/>
+<Type name="QUBE_3" class="3" element="F" mass="18.998"/>
+<Type name="QUBE_4" class="4" element="C" mass="12.011"/>
+<Type name="QUBE_5" class="5" element="C" mass="12.011"/>
+<Type name="QUBE_6" class="6" element="C" mass="12.011"/>
+<Type name="QUBE_7" class="7" element="O" mass="15.999"/>
+<Type name="QUBE_8" class="8" element="O" mass="15.999"/>
+<Type name="QUBE_9" class="9" element="C" mass="12.011"/>
+<Type name="QUBE_10" class="10" element="C" mass="12.011"/>
+<Type name="QUBE_11" class="11" element="C" mass="12.011"/>
+<Type name="QUBE_12" class="12" element="C" mass="12.011"/>
+<Type name="QUBE_13" class="13" element="C" mass="12.011"/>
+<Type name="QUBE_14" class="14" element="N" mass="14.007"/>
+<Type name="QUBE_15" class="15" element="C" mass="12.011"/>
+<Type name="QUBE_16" class="16" element="C" mass="12.011"/>
+<Type name="QUBE_17" class="17" element="C" mass="12.011"/>
+<Type name="QUBE_18" class="18" element="C" mass="12.011"/>
+<Type name="QUBE_19" class="19" element="C" mass="12.011"/>
+<Type name="QUBE_20" class="20" element="C" mass="12.011"/>
+<Type name="QUBE_21" class="21" element="C" mass="12.011"/>
+<Type name="QUBE_22" class="22" element="H" mass="1.008"/>
+<Type name="QUBE_23" class="23" element="H" mass="1.008"/>
+<Type name="QUBE_24" class="24" element="H" mass="1.008"/>
+<Type name="QUBE_25" class="25" element="H" mass="1.008"/>
+<Type name="QUBE_26" class="26" element="H" mass="1.008"/>
+<Type name="QUBE_27" class="27" element="H" mass="1.008"/>
+<Type name="QUBE_28" class="28" element="H" mass="1.008"/>
+<Type name="QUBE_29" class="29" element="H" mass="1.008"/>
+<Type name="QUBE_30" class="30" element="H" mass="1.008"/>
+<Type name="QUBE_31" class="31" element="H" mass="1.008"/>
+<Type name="QUBE_32" class="32" element="H" mass="1.008"/>
+<Type name="QUBE_33" class="33" element="H" mass="1.008"/>
+<Type name="QUBE_34" class="34" element="H" mass="1.008"/>
+<Type name="QUBE_35" class="35" element="H" mass="1.008"/>
+<Type name="v-site1" class="X1" mass="0"/>
+<Type name="v-site2" class="X2" mass="0"/>
+</AtomTypes>
+<Residues>
+<Residue name="MOL">
+<Atom name="F1" type="QUBE_0"/>
+<Atom name="C1" type="QUBE_1"/>
+<Atom name="F2" type="QUBE_2"/>
+<Atom name="F3" type="QUBE_3"/>
+<Atom name="C2" type="QUBE_4"/>
+<Atom name="C3" type="QUBE_5"/>
+<Atom name="C4" type="QUBE_6"/>
+<Atom name="O1" type="QUBE_7"/>
+<Atom name="O2" type="QUBE_8"/>
+<Atom name="C5" type="QUBE_9"/>
+<Atom name="C6" type="QUBE_10"/>
+<Atom name="C7" type="QUBE_11"/>
+<Atom name="C8" type="QUBE_12"/>
+<Atom name="C9" type="QUBE_13"/>
+<Atom name="N1" type="QUBE_14"/>
+<Atom name="C10" type="QUBE_15"/>
+<Atom name="C11" type="QUBE_16"/>
+<Atom name="C12" type="QUBE_17"/>
+<Atom name="C13" type="QUBE_18"/>
+<Atom name="C14" type="QUBE_19"/>
+<Atom name="C15" type="QUBE_20"/>
+<Atom name="C16" type="QUBE_21"/>
+<Atom name="H1" type="QUBE_22"/>
+<Atom name="H2" type="QUBE_23"/>
+<Atom name="H3" type="QUBE_24"/>
+<Atom name="H4" type="QUBE_25"/>
+<Atom name="H5" type="QUBE_26"/>
+<Atom name="H6" type="QUBE_27"/>
+<Atom name="H7" type="QUBE_28"/>
+<Atom name="H8" type="QUBE_29"/>
+<Atom name="H9" type="QUBE_30"/>
+<Atom name="H10" type="QUBE_31"/>
+<Atom name="H11" type="QUBE_32"/>
+<Atom name="H12" type="QUBE_33"/>
+<Atom name="H13" type="QUBE_34"/>
+<Atom name="H14" type="QUBE_35"/>
+<Atom name="X1" type="v-site1"/>
+<Atom name="X2" type="v-site2"/>
+<Bond from="0" to="1"/>
+<Bond from="1" to="2"/>
+<Bond from="1" to="3"/>
+<Bond from="1" to="4"/>
+<Bond from="4" to="5"/>
+<Bond from="4" to="20"/>
+<Bond from="5" to="6"/>
+<Bond from="5" to="22"/>
+<Bond from="6" to="7"/>
+<Bond from="6" to="8"/>
+<Bond from="8" to="9"/>
+<Bond from="9" to="10"/>
+<Bond from="9" to="20"/>
+<Bond from="10" to="11"/>
+<Bond from="10" to="21"/>
+<Bond from="11" to="12"/>
+<Bond from="11" to="23"/>
+<Bond from="11" to="24"/>
+<Bond from="12" to="13"/>
+<Bond from="12" to="25"/>
+<Bond from="12" to="26"/>
+<Bond from="13" to="14"/>
+<Bond from="13" to="27"/>
+<Bond from="13" to="28"/>
+<Bond from="14" to="15"/>
+<Bond from="14" to="21"/>
+<Bond from="15" to="16"/>
+<Bond from="15" to="29"/>
+<Bond from="15" to="30"/>
+<Bond from="16" to="17"/>
+<Bond from="16" to="31"/>
+<Bond from="16" to="32"/>
+<Bond from="17" to="18"/>
+<Bond from="17" to="33"/>
+<Bond from="17" to="34"/>
+<Bond from="18" to="19"/>
+<Bond from="18" to="21"/>
+<Bond from="19" to="20"/>
+<Bond from="19" to="35"/>
+<VirtualSite p1="-0.0307" p2="-0.0566" p3="0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="36"/>
+<VirtualSite p1="-0.0307" p2="-0.0566" p3="-0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="37"/>
+</Residue>
+</Residues>
+<HarmonicBondForce>
+<Bond length="0.13496011742992933" k="259586.48572299856" class1="0" class2="1"/>
+<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="2"/>
+<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="205802.9322041371" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="460185.44749956" class1="4" class2="5"/>
+<Bond length="0.14424155029894592" k="249691.30512503046" class1="4" class2="20"/>
+<Bond length="0.14564591082883707" k="229554.39047817126" class1="5" class2="6"/>
+<Bond length="0.10814511275621548" k="339079.2187655641" class1="5" class2="22"/>
+<Bond length="0.12065331189134901" k="705656.5336934443" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="215319.235157788" class1="6" class2="8"/>
+<Bond length="0.13688031490221975" k="258901.85615222016" class1="8" class2="9"/>
+<Bond length="0.13896874772055995" k="321973.43282597023" class1="9" class2="10"/>
+<Bond length="0.14002870254626093" k="295881.97483721166" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="199307.7600148271" class1="10" class2="11"/>
+<Bond length="0.14097123172598094" k="290372.52500279003" class1="10" class2="21"/>
+<Bond length="0.15240838998674713" k="198283.7633359121" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="295506.05426352075" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="295506.05426352075" class1="11" class2="24"/>
+<Bond length="0.151952792468063" k="201970.0217351758" class1="12" class2="13"/>
+<Bond length="0.10953626718429421" k="296694.52998631075" class1="12" class2="25"/>
+<Bond length="0.10953626718429421" k="296694.52998631075" class1="12" class2="26"/>
+<Bond length="0.14540752871782298" k="214895.31119640742" class1="13" class2="14"/>
+<Bond length="0.10989784615609387" k="286578.48647712264" class1="13" class2="27"/>
+<Bond length="0.10989784615609387" k="286578.48647712264" class1="13" class2="28"/>
+<Bond length="0.14539815451968735" k="215777.7380434388" class1="14" class2="15"/>
+<Bond length="0.1382504797109479" k="280264.52123681555" class1="14" class2="21"/>
+<Bond length="0.15197197918433356" k="202787.47629810506" class1="15" class2="16"/>
+<Bond length="0.10992030880021078" k="285946.38304967096" class1="15" class2="29"/>
+<Bond length="0.10992030880021078" k="285946.38304967096" class1="15" class2="30"/>
+<Bond length="0.1523393762132001" k="196415.7185398004" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="296569.2864479516" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="296569.2864479516" class1="16" class2="32"/>
+<Bond length="0.15125045314560476" k="203945.24729604847" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="292364.33657480346" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="292364.33657480346" class1="17" class2="34"/>
+<Bond length="0.13769965673158013" k="366734.9303769713" class1="18" class2="19"/>
+<Bond length="0.1423991064559355" k="261826.37957296983" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="307930.7671318767" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="326603.41920538543" class1="19" class2="35"/>
+</HarmonicBondForce>
+<HarmonicAngleForce>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
+<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="808.8627774996936" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="639.7476858128786" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="262.3563023615395" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="557.4746848468715" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="807.9095983882028" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="552.9254852453236" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="751.8116762302967" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
+<Angle k="718.830040433039" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="553.7538746695924" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="648.9592299042741" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
+<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="1121.6908591863469" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
+<Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="795.9032365496385" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
+<Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="1061.3339489822274" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
+<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
+<Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="27"/>
+<Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="28"/>
+<Angle k="1043.2371059142824" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
+<Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="29"/>
+<Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="30"/>
+<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
+<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
+<Angle k="1017.6871864118357" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
+<Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="1173.139818868356" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
+<Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
+<Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="700.965705603468" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="282.6287693615428" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
+<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="264.5571241818087" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
+<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
+<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
+<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+</HarmonicAngleForce>
+<PeriodicTorsionForce ordering="smirnoff">
+<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
+<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+</PeriodicTorsionForce>
+<NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
+<Atom charge="-0.25233" epsilon="0.24312107096883973" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="0.776573" epsilon="0.3137621288766835" sigma="0.29731865548843023" type="QUBE_1"/>
+<Atom charge="-0.242744" epsilon="0.24178358454706314" sigma="0.29666886791766617" type="QUBE_2"/>
+<Atom charge="-0.251133" epsilon="0.24306111392023294" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.051181" epsilon="0.3617577618615011" sigma="0.33069182353388327" type="QUBE_4"/>
+<Atom charge="-0.303105" epsilon="0.3772809207194576" sigma="0.34124081032064807" type="QUBE_5"/>
+<Atom charge="0.667684" epsilon="0.313609862900308" sigma="0.2972108117286001" type="QUBE_6"/>
+<Atom charge="-0.56416" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
+<Atom charge="-0.158328" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
+<Atom charge="0.227775" epsilon="0.3436932883429018" sigma="0.318270617002993" type="QUBE_9"/>
+<Atom charge="-0.120378" epsilon="0.36665208454511444" sigma="0.3340299552647392" type="QUBE_10"/>
+<Atom charge="-0.150389" epsilon="0.36713490953834793" sigma="0.3343586499521666" type="QUBE_11"/>
+<Atom charge="-0.159758" epsilon="0.36290613515097186" sigma="0.33147608094404685" type="QUBE_12"/>
+<Atom charge="-0.024505" epsilon="0.3544167083140162" sigma="0.3256634315637403" type="QUBE_13"/>
+<Atom charge="-0.157381" epsilon="0.4251728424952781" sigma="0.3123029822966852" type="QUBE_14"/>
+<Atom charge="-0.024064" epsilon="0.3543848330174416" sigma="0.32564154095384984" type="QUBE_15"/>
+<Atom charge="-0.166073" epsilon="0.3640118462523035" sigma="0.3322306109040008" type="QUBE_16"/>
+<Atom charge="-0.157372" epsilon="0.3651594603211226" sigma="0.33301312312809483" type="QUBE_17"/>
+<Atom charge="0.000334" epsilon="0.35761062652246195" sigma="0.3278543676906809" type="QUBE_18"/>
+<Atom charge="-0.167065" epsilon="0.3784651509848419" sigma="0.3420410206882571" type="QUBE_19"/>
+<Atom charge="-0.078422" epsilon="0.36713419029681693" sigma="0.33435816039249844" type="QUBE_20"/>
+<Atom charge="0.155012" epsilon="0.34902004099725037" sigma="0.3219500963762515" type="QUBE_21"/>
+<Atom charge="0.167521" epsilon="0.08327170335092592" sigma="0.24047595644632233" type="QUBE_22"/>
+<Atom charge="0.097355" epsilon="0.08581986873989693" sigma="0.24595475122945462" type="QUBE_23"/>
+<Atom charge="0.090775" epsilon="0.08647598481424516" sigma="0.2473587724974695" type="QUBE_24"/>
+<Atom charge="0.091394" epsilon="0.08531979298529052" sigma="0.24488281892469482" type="QUBE_25"/>
+<Atom charge="0.095147" epsilon="0.08315967981655392" sigma="0.24023413144449074" type="QUBE_26"/>
+<Atom charge="0.078988" epsilon="0.08576997248810035" sigma="0.24584786762792243" type="QUBE_27"/>
+<Atom charge="0.061498" epsilon="0.08873187374227504" sigma="0.2521657872781152" type="QUBE_28"/>
+<Atom charge="0.079282" epsilon="0.08564449238725468" sigma="0.24557900513941391" type="QUBE_29"/>
+<Atom charge="0.06061" epsilon="0.08870029760695072" sigma="0.2520987171872303" type="QUBE_30"/>
+<Atom charge="0.093159" epsilon="0.08540001689934773" sigma="0.24505488874102366" type="QUBE_31"/>
+<Atom charge="0.096345" epsilon="0.08324137505423658" sigma="0.24041049492409503" type="QUBE_32"/>
+<Atom charge="0.096629" epsilon="0.08421113158571183" sigma="0.2425006780809266" type="QUBE_33"/>
+<Atom charge="0.087509" epsilon="0.08628029498385563" sigma="0.24694029878997514" type="QUBE_34"/>
+<Atom charge="0.113032" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
+<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site1"/>
+<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site2"/>
+</NonbondedForce>
+</ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-qcforce-ub-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-qcforce-ub-rfree.xml
@@ -1,0 +1,483 @@
+<?xml version="1.0" ?>
+<ForceField>
+<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<AtomTypes>
+<Type name="QUBE_0" class="0" element="F" mass="18.998"/>
+<Type name="QUBE_1" class="1" element="C" mass="12.011"/>
+<Type name="QUBE_2" class="2" element="F" mass="18.998"/>
+<Type name="QUBE_3" class="3" element="F" mass="18.998"/>
+<Type name="QUBE_4" class="4" element="C" mass="12.011"/>
+<Type name="QUBE_5" class="5" element="C" mass="12.011"/>
+<Type name="QUBE_6" class="6" element="C" mass="12.011"/>
+<Type name="QUBE_7" class="7" element="O" mass="15.999"/>
+<Type name="QUBE_8" class="8" element="O" mass="15.999"/>
+<Type name="QUBE_9" class="9" element="C" mass="12.011"/>
+<Type name="QUBE_10" class="10" element="C" mass="12.011"/>
+<Type name="QUBE_11" class="11" element="C" mass="12.011"/>
+<Type name="QUBE_12" class="12" element="C" mass="12.011"/>
+<Type name="QUBE_13" class="13" element="C" mass="12.011"/>
+<Type name="QUBE_14" class="14" element="N" mass="14.007"/>
+<Type name="QUBE_15" class="15" element="C" mass="12.011"/>
+<Type name="QUBE_16" class="16" element="C" mass="12.011"/>
+<Type name="QUBE_17" class="17" element="C" mass="12.011"/>
+<Type name="QUBE_18" class="18" element="C" mass="12.011"/>
+<Type name="QUBE_19" class="19" element="C" mass="12.011"/>
+<Type name="QUBE_20" class="20" element="C" mass="12.011"/>
+<Type name="QUBE_21" class="21" element="C" mass="12.011"/>
+<Type name="QUBE_22" class="22" element="H" mass="1.008"/>
+<Type name="QUBE_23" class="23" element="H" mass="1.008"/>
+<Type name="QUBE_24" class="24" element="H" mass="1.008"/>
+<Type name="QUBE_25" class="25" element="H" mass="1.008"/>
+<Type name="QUBE_26" class="26" element="H" mass="1.008"/>
+<Type name="QUBE_27" class="27" element="H" mass="1.008"/>
+<Type name="QUBE_28" class="28" element="H" mass="1.008"/>
+<Type name="QUBE_29" class="29" element="H" mass="1.008"/>
+<Type name="QUBE_30" class="30" element="H" mass="1.008"/>
+<Type name="QUBE_31" class="31" element="H" mass="1.008"/>
+<Type name="QUBE_32" class="32" element="H" mass="1.008"/>
+<Type name="QUBE_33" class="33" element="H" mass="1.008"/>
+<Type name="QUBE_34" class="34" element="H" mass="1.008"/>
+<Type name="QUBE_35" class="35" element="H" mass="1.008"/>
+<Type name="v-site1" class="X1" mass="0"/>
+<Type name="v-site2" class="X2" mass="0"/>
+</AtomTypes>
+<Residues>
+<Residue name="MOL">
+<Atom name="F1" type="QUBE_0"/>
+<Atom name="C1" type="QUBE_1"/>
+<Atom name="F2" type="QUBE_2"/>
+<Atom name="F3" type="QUBE_3"/>
+<Atom name="C2" type="QUBE_4"/>
+<Atom name="C3" type="QUBE_5"/>
+<Atom name="C4" type="QUBE_6"/>
+<Atom name="O1" type="QUBE_7"/>
+<Atom name="O2" type="QUBE_8"/>
+<Atom name="C5" type="QUBE_9"/>
+<Atom name="C6" type="QUBE_10"/>
+<Atom name="C7" type="QUBE_11"/>
+<Atom name="C8" type="QUBE_12"/>
+<Atom name="C9" type="QUBE_13"/>
+<Atom name="N1" type="QUBE_14"/>
+<Atom name="C10" type="QUBE_15"/>
+<Atom name="C11" type="QUBE_16"/>
+<Atom name="C12" type="QUBE_17"/>
+<Atom name="C13" type="QUBE_18"/>
+<Atom name="C14" type="QUBE_19"/>
+<Atom name="C15" type="QUBE_20"/>
+<Atom name="C16" type="QUBE_21"/>
+<Atom name="H1" type="QUBE_22"/>
+<Atom name="H2" type="QUBE_23"/>
+<Atom name="H3" type="QUBE_24"/>
+<Atom name="H4" type="QUBE_25"/>
+<Atom name="H5" type="QUBE_26"/>
+<Atom name="H6" type="QUBE_27"/>
+<Atom name="H7" type="QUBE_28"/>
+<Atom name="H8" type="QUBE_29"/>
+<Atom name="H9" type="QUBE_30"/>
+<Atom name="H10" type="QUBE_31"/>
+<Atom name="H11" type="QUBE_32"/>
+<Atom name="H12" type="QUBE_33"/>
+<Atom name="H13" type="QUBE_34"/>
+<Atom name="H14" type="QUBE_35"/>
+<Atom name="X1" type="v-site1"/>
+<Atom name="X2" type="v-site2"/>
+<Bond from="0" to="1"/>
+<Bond from="1" to="2"/>
+<Bond from="1" to="3"/>
+<Bond from="1" to="4"/>
+<Bond from="4" to="5"/>
+<Bond from="4" to="20"/>
+<Bond from="5" to="6"/>
+<Bond from="5" to="22"/>
+<Bond from="6" to="7"/>
+<Bond from="6" to="8"/>
+<Bond from="8" to="9"/>
+<Bond from="9" to="10"/>
+<Bond from="9" to="20"/>
+<Bond from="10" to="11"/>
+<Bond from="10" to="21"/>
+<Bond from="11" to="12"/>
+<Bond from="11" to="23"/>
+<Bond from="11" to="24"/>
+<Bond from="12" to="13"/>
+<Bond from="12" to="25"/>
+<Bond from="12" to="26"/>
+<Bond from="13" to="14"/>
+<Bond from="13" to="27"/>
+<Bond from="13" to="28"/>
+<Bond from="14" to="15"/>
+<Bond from="14" to="21"/>
+<Bond from="15" to="16"/>
+<Bond from="15" to="29"/>
+<Bond from="15" to="30"/>
+<Bond from="16" to="17"/>
+<Bond from="16" to="31"/>
+<Bond from="16" to="32"/>
+<Bond from="17" to="18"/>
+<Bond from="17" to="33"/>
+<Bond from="17" to="34"/>
+<Bond from="18" to="19"/>
+<Bond from="18" to="21"/>
+<Bond from="19" to="20"/>
+<Bond from="19" to="35"/>
+<Bond from="0" to="2"/>
+<Bond from="0" to="3"/>
+<Bond from="0" to="4"/>
+<Bond from="1" to="5"/>
+<Bond from="1" to="20"/>
+<Bond from="2" to="3"/>
+<Bond from="2" to="4"/>
+<Bond from="3" to="4"/>
+<Bond from="4" to="6"/>
+<Bond from="4" to="22"/>
+<Bond from="4" to="9"/>
+<Bond from="4" to="19"/>
+<Bond from="5" to="20"/>
+<Bond from="5" to="7"/>
+<Bond from="5" to="8"/>
+<Bond from="6" to="22"/>
+<Bond from="6" to="9"/>
+<Bond from="7" to="8"/>
+<Bond from="8" to="10"/>
+<Bond from="8" to="20"/>
+<Bond from="9" to="11"/>
+<Bond from="9" to="21"/>
+<Bond from="9" to="19"/>
+<Bond from="10" to="20"/>
+<Bond from="10" to="12"/>
+<Bond from="10" to="23"/>
+<Bond from="10" to="24"/>
+<Bond from="10" to="14"/>
+<Bond from="10" to="18"/>
+<Bond from="11" to="21"/>
+<Bond from="11" to="13"/>
+<Bond from="11" to="25"/>
+<Bond from="11" to="26"/>
+<Bond from="12" to="23"/>
+<Bond from="12" to="24"/>
+<Bond from="12" to="14"/>
+<Bond from="12" to="27"/>
+<Bond from="12" to="28"/>
+<Bond from="13" to="25"/>
+<Bond from="13" to="26"/>
+<Bond from="13" to="15"/>
+<Bond from="13" to="21"/>
+<Bond from="14" to="27"/>
+<Bond from="14" to="28"/>
+<Bond from="14" to="16"/>
+<Bond from="14" to="29"/>
+<Bond from="14" to="30"/>
+<Bond from="14" to="18"/>
+<Bond from="15" to="21"/>
+<Bond from="15" to="17"/>
+<Bond from="15" to="31"/>
+<Bond from="15" to="32"/>
+<Bond from="16" to="29"/>
+<Bond from="16" to="30"/>
+<Bond from="16" to="18"/>
+<Bond from="16" to="33"/>
+<Bond from="16" to="34"/>
+<Bond from="17" to="31"/>
+<Bond from="17" to="32"/>
+<Bond from="17" to="19"/>
+<Bond from="17" to="21"/>
+<Bond from="18" to="33"/>
+<Bond from="18" to="34"/>
+<Bond from="18" to="20"/>
+<Bond from="18" to="35"/>
+<Bond from="19" to="21"/>
+<Bond from="20" to="35"/>
+<Bond from="23" to="24"/>
+<Bond from="25" to="26"/>
+<Bond from="27" to="28"/>
+<Bond from="29" to="30"/>
+<Bond from="31" to="32"/>
+<Bond from="33" to="34"/>
+<VirtualSite p1="-0.0307" p2="-0.0566" p3="0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="36"/>
+<VirtualSite p1="-0.0307" p2="-0.0566" p3="-0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="37"/>
+</Residue>
+</Residues>
+<HarmonicBondForce>
+<Bond length="0.13469356407442745" k="248710.72048826894" class1="0" class2="1"/>
+<Bond length="0.13469356407442745" k="248710.72048826894" class1="1" class2="2"/>
+<Bond length="0.13469356407442745" k="248710.72048826894" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="218125.2973797079" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="452537.0120235957" class1="4" class2="5"/>
+<Bond length="0.14424155029894592" k="235785.886002724" class1="4" class2="20"/>
+<Bond length="0.14564591082883707" k="214126.92128785737" class1="5" class2="6"/>
+<Bond length="0.10814511275621548" k="337583.37226720486" class1="5" class2="22"/>
+<Bond length="0.12065331189134901" k="697181.8374609897" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="170764.06572729698" class1="6" class2="8"/>
+<Bond length="0.13688031490221975" k="246190.18785439065" class1="8" class2="9"/>
+<Bond length="0.13896874772055995" k="302717.2225235032" class1="9" class2="10"/>
+<Bond length="0.14002870254626093" k="278746.28794164985" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="198333.8619132481" class1="10" class2="11"/>
+<Bond length="0.14097123172598094" k="267347.65667859913" class1="10" class2="21"/>
+<Bond length="0.15240838998674713" k="188827.0108461436" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="298264.66152674344" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="298264.66152674344" class1="11" class2="24"/>
+<Bond length="0.15195279246806304" k="191034.5384730615" class1="12" class2="13"/>
+<Bond length="0.1095362671842942" k="299524.17045776814" class1="12" class2="25"/>
+<Bond length="0.1095362671842942" k="299524.17045776814" class1="12" class2="26"/>
+<Bond length="0.14540284161875516" k="204810.5084630868" class1="13" class2="14"/>
+<Bond length="0.10990907747815233" k="289936.61477030907" class1="13" class2="27"/>
+<Bond length="0.10990907747815233" k="289936.61477030907" class1="13" class2="28"/>
+<Bond length="0.14540284161875516" k="204810.5084630868" class1="14" class2="15"/>
+<Bond length="0.1382504797109479" k="275225.2410849799" class1="14" class2="21"/>
+<Bond length="0.15197197918433358" k="190718.45269290742" class1="15" class2="16"/>
+<Bond length="0.10990907747815233" k="289936.61477030907" class1="15" class2="29"/>
+<Bond length="0.10990907747815233" k="289936.61477030907" class1="15" class2="30"/>
+<Bond length="0.15233937621320012" k="188429.22378711312" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="299171.8758940889" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="299171.8758940889" class1="16" class2="32"/>
+<Bond length="0.15125045314560479" k="200860.66147330133" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="295046.6169804358" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="295046.6169804358" class1="17" class2="34"/>
+<Bond length="0.13769965673158013" k="350155.32734256436" class1="18" class2="19"/>
+<Bond length="0.14239910645593554" k="236954.7779603677" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="290675.9943500282" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="332788.9040241763" class1="19" class2="35"/>
+<Bond length="0.21652967675118645" k="65752.2685533569" class1="0" class2="2"/>
+<Bond length="0.21652967675118645" k="65752.2685533569" class1="0" class2="3"/>
+<Bond length="0.2367308754593913" k="35097.51844577419" class1="0" class2="4"/>
+<Bond length="0.24637183735463966" k="22766.286083202882" class1="1" class2="5"/>
+<Bond length="0.2552484693842637" k="33308.821775625285" class1="1" class2="20"/>
+<Bond length="0.21652967675118645" k="65752.2685533569" class1="2" class2="3"/>
+<Bond length="0.2367308754593913" k="35097.51844577419" class1="2" class2="4"/>
+<Bond length="0.2367308754593913" k="35097.51844577419" class1="3" class2="4"/>
+<Bond length="0.24424950724834102" k="33413.30187459911" class1="4" class2="6"/>
+<Bond length="0.2137728474468069" k="14026.150021973126" class1="4" class2="22"/>
+<Bond length="0.24235320460628298" k="29359.23491262911" class1="4" class2="9"/>
+<Bond length="0.25380961300478017" k="37919.66966642074" class1="4" class2="19"/>
+<Bond length="0.24317848563613786" k="49748.88547849213" class1="5" class2="20"/>
+<Bond length="0.23691569131052775" k="62595.152719528414" class1="5" class2="7"/>
+<Bond length="0.2404062775308595" k="36240.16958437524" class1="5" class2="8"/>
+<Bond length="0.21616921612132547" k="16590.049023226384" class1="6" class2="22"/>
+<Bond length="0.24155207989996136" k="44506.468345945024" class1="6" class2="9"/>
+<Bond length="0.22173066563125332" k="94729.48975647744" class1="7" class2="8"/>
+<Bond length="0.23348443062234248" k="57554.66560831616" class1="8" class2="10"/>
+<Bond length="0.2409996256628092" k="33046.49277275733" class1="8" class2="20"/>
+<Bond length="0.2508615762103375" k="19610.01547957706" class1="9" class2="11"/>
+<Bond length="0.2403603662334068" k="50325.95005177289" class1="9" class2="21"/>
+<Bond length="0.23893622663484204" k="45529.13501093602" class1="9" class2="19"/>
+<Bond length="0.24561151969819398" k="40743.13462124213" class1="10" class2="20"/>
+<Bond length="0.25043517668197823" k="21505.46413599935" class1="10" class2="12"/>
+<Bond length="0.2143215696888813" k="17904.811736016643" class1="10" class2="23"/>
+<Bond length="0.2143215696888813" k="17904.811736016643" class1="10" class2="24"/>
+<Bond length="0.24191336629679144" k="47097.831805307374" class1="10" class2="14"/>
+<Bond length="0.2449311721801657" k="42402.55603279804" class1="10" class2="18"/>
+<Bond length="0.2554238649411517" k="15377.298529872323" class1="11" class2="21"/>
+<Bond length="0.24943515144206752" k="32195.329208063562" class1="11" class2="13"/>
+<Bond length="0.21638649819857225" k="11503.954947145208" class1="11" class2="25"/>
+<Bond length="0.21638649819857225" k="11503.954947145208" class1="11" class2="26"/>
+<Bond length="0.21637698760602225" k="11672.974219363094" class1="12" class2="23"/>
+<Bond length="0.21637698760602225" k="11672.974219363094" class1="12" class2="24"/>
+<Bond length="0.2445664336412628" k="33256.01522279772" class1="12" class2="14"/>
+<Bond length="0.21627463620927637" k="11491.033607839858" class1="12" class2="27"/>
+<Bond length="0.21627463620927637" k="11491.033607839858" class1="12" class2="28"/>
+<Bond length="0.2146925734975977" k="13360.26816805869" class1="13" class2="25"/>
+<Bond length="0.2146925734975977" k="13360.26816805869" class1="13" class2="26"/>
+<Bond length="0.2466018129470507" k="3736.7354885250256" class1="13" class2="15"/>
+<Bond length="0.24530456727951677" k="26062.586271548935" class1="13" class2="21"/>
+<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="27"/>
+<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="28"/>
+<Bond length="0.24506286921679699" k="33221.952059765485" class1="14" class2="16"/>
+<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="29"/>
+<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="30"/>
+<Bond length="0.24341685186846426" k="45678.9365063201" class1="14" class2="18"/>
+<Bond length="0.24530456727951677" k="26062.586271548935" class1="15" class2="21"/>
+<Bond length="0.2482899688867673" k="31024.378168591185" class1="15" class2="17"/>
+<Bond length="0.21482896649717576" k="13667.387394240935" class1="15" class2="31"/>
+<Bond length="0.21482896649717576" k="13667.387394240935" class1="15" class2="32"/>
+<Bond length="0.2161210191868845" k="10740.514701412663" class1="16" class2="29"/>
+<Bond length="0.2161210191868845" k="10740.514701412663" class1="16" class2="30"/>
+<Bond length="0.25071186281720664" k="21767.12177986897" class1="16" class2="18"/>
+<Bond length="0.21588768954068127" k="12305.051141155052" class1="16" class2="33"/>
+<Bond length="0.21588768954068127" k="12305.051141155052" class1="16" class2="34"/>
+<Bond length="0.2166014429827969" k="11757.510013757139" class1="17" class2="31"/>
+<Bond length="0.2166014429827969" k="11757.510013757139" class1="17" class2="32"/>
+<Bond length="0.2501622513015905" k="13468.893552980422" class1="17" class2="19"/>
+<Bond length="0.25504206857818595" k="17020.18071746364" class1="17" class2="21"/>
+<Bond length="0.2145767289449851" k="15224.635392491049" class1="18" class2="33"/>
+<Bond length="0.2145767289449851" k="15224.635392491049" class1="18" class2="34"/>
+<Bond length="0.24352193235081798" k="52903.72109806267" class1="18" class2="20"/>
+<Bond length="0.21177124922411472" k="8020.984179537393" class1="18" class2="35"/>
+<Bond length="0.24207073997933107" k="54060.175707486436" class1="19" class2="21"/>
+<Bond length="0.21560948327565438" k="10601.247393547372" class1="20" class2="35"/>
+<Bond length="0.17462080461979723" k="13702.455171858066" class1="23" class2="24"/>
+<Bond length="0.17661650584198943" k="13363.67976471447" class1="25" class2="26"/>
+<Bond length="0.17685797959042412" k="13047.147646234267" class1="27" class2="28"/>
+<Bond length="0.17685797959042412" k="13047.147646234267" class1="29" class2="30"/>
+<Bond length="0.1767871797367549" k="13194.049029061343" class1="31" class2="32"/>
+<Bond length="0.17560269028929812" k="13761.299394180302" class1="33" class2="34"/>
+</HarmonicBondForce>
+<HarmonicAngleForce>
+<Angle k="636.4040553561965" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
+<Angle k="636.4040553561965" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
+<Angle k="534.1866551637136" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
+<Angle k="409.71521276491893" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="136.79997336432282" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="636.4040553561965" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="534.1866551637136" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
+<Angle k="534.1866551637136" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="596.7728846990148" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="251.3358417912241" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="548.0435606806428" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="678.2808594294862" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="94.20048681133204" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="247.22531384335034" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="112.52203837797829" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="212.3218943278685" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="474.6411980162593" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="769.6873434595309" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="658.266039158154" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
+<Angle k="438.2022748632177" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="316.6019984663359" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="401.91551591572727" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
+<Angle k="303.51197633594205" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="103.31247281062609" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="400.48689576331174" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
+<Angle k="295.20302696156057" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="295.20302696156057" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="598.9610350044281" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="105.78200812731957" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="422.37009093288634" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="604.8643424849223" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="354.7085988438403" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
+<Angle k="354.7085988438403" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
+<Angle k="347.52226423238415" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="347.52226423238415" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="522.2572264706107" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="352.21015548084887" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="352.21015548084887" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="342.2696819227702" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
+<Angle k="342.2696819227702" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
+<Angle k="627.0430471983619" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="333.3950317013976" angle="2.0891509949808236" class1="13" class2="14" class3="21"/>
+<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
+<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
+<Angle k="513.6010207608534" angle="1.9368432495236967" class1="14" class2="15" class3="16"/>
+<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
+<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
+<Angle k="618.3762057433295" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
+<Angle k="333.3950317013976" angle="2.0891509949808236" class1="15" class2="14" class3="21"/>
+<Angle k="614.3379233697891" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="343.4470607410886" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
+<Angle k="343.4470607410886" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
+<Angle k="358.82189452864463" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="358.82189452864463" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="373.6632811649154" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
+<Angle k="353.34730540873824" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="353.34730540873824" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="361.5158176709999" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="361.5158176709999" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="536.6295412302601" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="419.4058971998923" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="299.5772155612874" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
+<Angle k="299.5772155612874" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="231.37386417830206" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="326.0736683080835" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
+<Angle k="372.4825926009225" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="193.55670775969207" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="262.1432565874291" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
+<Angle k="270.96482284955744" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="261.9334015695606" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
+<Angle k="261.9334015695606" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
+<Angle k="267.4878637894604" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="273.5497074794414" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+</HarmonicAngleForce>
+<PeriodicTorsionForce ordering="charmm">
+<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="14.987254051360019" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="24.161434815972157" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="13.840603003560435" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0" k2="62.76434875493169" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="43.05716767703306" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="14.099717731353625" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0" k2="32.11723285789512" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0" k2="20.14832280505608" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="6.238769556072177" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="21.396325246806697" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="7.412883360745509" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="11.037061048422125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.66341156914107" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="35.84782905877354" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="13.246741161068709" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.718641725188782" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0" k2="26.89869959283934" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="19.564641024974517" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="13.308366006520128" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="19.33552535369704" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="21.979979166611848" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0" k2="10.902709171624208" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0" k2="5.143393889179049" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="5.867161518059558" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0" k2="37.44189566323711" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="36.29213254589665" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="25.377563782046575" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0" k2="18.021356889874767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="26.66907635878022" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="4.234848872539599" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0" k2="22.933886285402842" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0" k2="21.533965765355514" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0" k2="2.644886174029585" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="22.668407575421234" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="20.10782046460023" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="21.470227795530203" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="3.4820300437332317" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0" k2="28.560156766840628" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+</PeriodicTorsionForce>
+<RBTorsionForce>
+<Proper c0="20.092" c1="57.654" c2="41.36" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.248" c1="82.84" c2="80.741" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="20.709" c1="80.092" c2="77.438" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="17.548" c1="54.416" c2="42.185" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
+</RBTorsionForce>
+<NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
+<Atom charge="-0.25233" epsilon="0.24312107096883973" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="0.776573" epsilon="0.3137621288766835" sigma="0.29731865548843023" type="QUBE_1"/>
+<Atom charge="-0.242744" epsilon="0.24178358454706314" sigma="0.29666886791766617" type="QUBE_2"/>
+<Atom charge="-0.251133" epsilon="0.24306111392023294" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.051181" epsilon="0.3617577618615011" sigma="0.33069182353388327" type="QUBE_4"/>
+<Atom charge="-0.303105" epsilon="0.3772809207194576" sigma="0.34124081032064807" type="QUBE_5"/>
+<Atom charge="0.667684" epsilon="0.313609862900308" sigma="0.2972108117286001" type="QUBE_6"/>
+<Atom charge="-0.56416" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
+<Atom charge="-0.158328" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
+<Atom charge="0.227775" epsilon="0.3436932883429018" sigma="0.318270617002993" type="QUBE_9"/>
+<Atom charge="-0.120378" epsilon="0.36665208454511444" sigma="0.3340299552647392" type="QUBE_10"/>
+<Atom charge="-0.150389" epsilon="0.36713490953834793" sigma="0.3343586499521666" type="QUBE_11"/>
+<Atom charge="-0.159758" epsilon="0.36290613515097186" sigma="0.33147608094404685" type="QUBE_12"/>
+<Atom charge="-0.024505" epsilon="0.3544167083140162" sigma="0.3256634315637403" type="QUBE_13"/>
+<Atom charge="-0.157381" epsilon="0.4251728424952781" sigma="0.3123029822966852" type="QUBE_14"/>
+<Atom charge="-0.024064" epsilon="0.3543848330174416" sigma="0.32564154095384984" type="QUBE_15"/>
+<Atom charge="-0.166073" epsilon="0.3640118462523035" sigma="0.3322306109040008" type="QUBE_16"/>
+<Atom charge="-0.157372" epsilon="0.3651594603211226" sigma="0.33301312312809483" type="QUBE_17"/>
+<Atom charge="0.000334" epsilon="0.35761062652246195" sigma="0.3278543676906809" type="QUBE_18"/>
+<Atom charge="-0.167065" epsilon="0.3784651509848419" sigma="0.3420410206882571" type="QUBE_19"/>
+<Atom charge="-0.078422" epsilon="0.36713419029681693" sigma="0.33435816039249844" type="QUBE_20"/>
+<Atom charge="0.155012" epsilon="0.34902004099725037" sigma="0.3219500963762515" type="QUBE_21"/>
+<Atom charge="0.167521" epsilon="0.08327170335092592" sigma="0.24047595644632233" type="QUBE_22"/>
+<Atom charge="0.097355" epsilon="0.08581986873989693" sigma="0.24595475122945462" type="QUBE_23"/>
+<Atom charge="0.090775" epsilon="0.08647598481424516" sigma="0.2473587724974695" type="QUBE_24"/>
+<Atom charge="0.091394" epsilon="0.08531979298529052" sigma="0.24488281892469482" type="QUBE_25"/>
+<Atom charge="0.095147" epsilon="0.08315967981655392" sigma="0.24023413144449074" type="QUBE_26"/>
+<Atom charge="0.078988" epsilon="0.08576997248810035" sigma="0.24584786762792243" type="QUBE_27"/>
+<Atom charge="0.061498" epsilon="0.08873187374227504" sigma="0.2521657872781152" type="QUBE_28"/>
+<Atom charge="0.079282" epsilon="0.08564449238725468" sigma="0.24557900513941391" type="QUBE_29"/>
+<Atom charge="0.06061" epsilon="0.08870029760695072" sigma="0.2520987171872303" type="QUBE_30"/>
+<Atom charge="0.093159" epsilon="0.08540001689934773" sigma="0.24505488874102366" type="QUBE_31"/>
+<Atom charge="0.096345" epsilon="0.08324137505423658" sigma="0.24041049492409503" type="QUBE_32"/>
+<Atom charge="0.096629" epsilon="0.08421113158571183" sigma="0.2425006780809266" type="QUBE_33"/>
+<Atom charge="0.087509" epsilon="0.08628029498385563" sigma="0.24694029878997514" type="QUBE_34"/>
+<Atom charge="0.113032" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
+<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site1"/>
+<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site2"/>
+</NonbondedForce>
+</ForceField>


### PR DESCRIPTION
Four new force fields are added, all of the non-bonded lennard-jones terms have been derived from a custom set of Rfree parameters which were fit using the method described [here](https://chemrxiv.org/engage/chemrxiv/article-details/61c0d3a31e13eb80bb0010ec) with and without v-sites. The AIM values were calculated at the `CAMB3LYP/6-31G* level`. 

The force fields with Modified Seminario bonded parameters were computed with QUBEKit version `2.1.1` which fixed a bug in the scaling applied to angle terms. 

```python
# Rfree used in qubekit to derive the no sites force field
no_sites_rfree = LennardJones612(
    lj_on_polar_h=True, 
    alpha=1.1458, 
    beta=0.4102, 
    free_parameters={
        "H": h_base(r_free=1.713),
        "C": c_base(r_free=2.04),
        "O": o_base(r_free=1.512),
        "N": n_base(r_free=1.741),
        "X": h_base(r_free=1.069),
        "F": f_base(r_free=1.637),
        "Cl": cl_base(r_free=1.836),
        "Br": br_base(r_free=1.991),
        "S": s_base(r_free=2.111)
    })

# Rfree used in qubekit to derive the sites force field
site_rfree = LennardJones612(
    lj_on_polar_h=True,
    alpha=1.063,
    beta=0.446,
    free_parameters={
        "H": h_base(r_free=1.730),
        "C": c_base(r_free=1.963),
        "O": o_base(r_free=1.603),
        "N": n_base(r_free=1.738),
        "X": h_base(r_free=1.324),
        "F": f_base(r_free=1.637),
        "Cl": cl_base(r_free=1.844),
        "Br": br_base(r_free=1.971),
        "S": s_base(r_free=1.999)
    }
)
```

## Force fields
- `coumarin-modsem-rfree.xml` QUBEKit+ModSem with no v-sites
- `coumarin-sites-modsem-rfree.xml` QUBEKit+ModSem with v-sites
- `coumarin-qcforce-ub-rfree.xml` QUBEKit+QForce with UB terms no v-sites
- `coumarin-sites-qcforce-ub-rfree.xml` QUBEKit+QForce with UB terms and v-sites.