### PR TITLE
Fix ub force fields

### DIFF
--- a/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-modsem-rfree.xml
+++ b/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-modsem-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1+18.g864d8cb.dirty" Date="2022_08_25"/>
+<QUBEKit Version="2.1.1+27.gac67d93.dirty" Date="2022_10_11"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -119,9 +119,9 @@
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13666787566738295" k="206214.74661105775" class1="0" class2="1"/>
-<Bond length="0.135578394121318" k="235028.7987340298" class1="1" class2="2"/>
-<Bond length="0.135578394121318" k="235028.7987340298" class1="1" class2="3"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="0" class2="1"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="1" class2="2"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="1" class2="3"/>
 <Bond length="0.14770475272616868" k="202636.90124838825" class1="1" class2="4"/>
 <Bond length="0.13961052875885102" k="347096.3654153404" class1="4" class2="5"/>
 <Bond length="0.1442192930696654" k="204687.21146882328" class1="4" class2="20"/>
@@ -162,219 +162,219 @@
 <HarmonicAngleForce>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="0" class2="1" class3="2"/>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="0" class2="1" class3="3"/>
-<Angle k="899.3585368640406" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
-<Angle k="596.5783996614795" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
-<Angle k="659.8801083115934" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="2" class2="1" class3="3"/>
+<Angle k="899.3585368640406" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
 <Angle k="899.3585368640406" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
 <Angle k="899.3585368640406" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
+<Angle k="596.5783996614795" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
+<Angle k="659.8801083115934" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
+<Angle k="521.025901967959" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
 <Angle k="607.8024679594919" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
 <Angle k="248.41301966022203" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
-<Angle k="672.8043009719439" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
-<Angle k="720.2813544945968" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
-<Angle k="521.025901967959" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
+<Angle k="252.09238388693245" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
 <Angle k="436.40842761557036" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
 <Angle k="554.0354749576979" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
-<Angle k="252.09238388693245" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
-<Angle k="1351.3545002900366" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
 <Angle k="514.1711048205738" angle="2.0126223566140804" class1="7" class2="6" class3="8"/>
+<Angle k="1351.3545002900366" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
 <Angle k="575.0175235407985" angle="2.013820749887496" class1="8" class2="9" class3="10"/>
 <Angle k="683.378020176922" angle="2.130524412137124" class1="8" class2="9" class3="20"/>
+<Angle k="716.5653468085275" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
 <Angle k="521.341642400924" angle="2.0882702117790397" class1="9" class2="10" class3="11"/>
 <Angle k="600.2256823226334" angle="2.075806905333667" class1="9" class2="10" class3="21"/>
-<Angle k="1116.5669365177487" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
-<Angle k="716.5653468085275" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
+<Angle k="593.550127606366" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
 <Angle k="1054.342543578456" angle="1.9408289971728419" class1="10" class2="11" class3="12"/>
 <Angle k="359.01398101206325" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
 <Angle k="359.01398101206325" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
-<Angle k="688.132896774631" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
-<Angle k="955.3354720930909" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
-<Angle k="593.550127606366" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
+<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
+<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
+<Angle k="340.43451985742695" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
 <Angle k="755.8333070341093" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
 <Angle k="422.53260308902185" angle="1.9290790266726685" class1="11" class2="12" class3="25"/>
 <Angle k="422.53260308902185" angle="1.9290790266726685" class1="11" class2="12" class3="26"/>
-<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
-<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
+<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
+<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
+<Angle k="308.2771278768513" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
 <Angle k="1058.9233469388728" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
 <Angle k="469.49389457008635" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
 <Angle k="469.49389457008635" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
-<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
-<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
-<Angle k="683.8532127510415" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
-<Angle k="653.9512111145623" angle="2.1049921908657305" class1="13" class2="14" class3="21"/>
 <Angle k="485.83278011238633" angle="1.8934542661534206" class1="14" class2="13" class3="27"/>
 <Angle k="485.83278011238633" angle="1.8934542661534206" class1="14" class2="13" class3="28"/>
+<Angle k="354.75833684494916" angle="1.8733192331827726" class1="27" class2="13" class3="28"/>
+<Angle k="683.8532127510415" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
+<Angle k="653.9512111145623" angle="2.1049921908657305" class1="13" class2="14" class3="21"/>
+<Angle k="637.1730113108624" angle="2.1139000267281434" class1="15" class2="14" class3="21"/>
 <Angle k="1038.0344508726746" angle="1.9473052141515759" class1="14" class2="15" class3="16"/>
 <Angle k="462.6560372351371" angle="1.8928233604685727" class1="14" class2="15" class3="29"/>
 <Angle k="462.6560372351371" angle="1.8928233604685727" class1="14" class2="15" class3="30"/>
-<Angle k="724.0638672794921" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
-<Angle k="637.1730113108624" angle="2.1139000267281434" class1="15" class2="14" class3="21"/>
+<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
+<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
+<Angle k="367.6928799885423" angle="1.870916290698717" class1="29" class2="15" class3="30"/>
 <Angle k="835.7646154944775" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
 <Angle k="515.6437119630667" angle="1.9073030765505146" class1="15" class2="16" class3="31"/>
 <Angle k="515.6437119630667" angle="1.9073030765505146" class1="15" class2="16" class3="32"/>
-<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
-<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
+<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
+<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
+<Angle k="298.9762404834261" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
 <Angle k="1076.1529378317775" angle="1.9368504917581069" class1="16" class2="17" class3="18"/>
 <Angle k="437.7829056469467" angle="1.922073455348455" class1="16" class2="17" class3="33"/>
 <Angle k="437.7829056469467" angle="1.922073455348455" class1="16" class2="17" class3="34"/>
-<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
-<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
-<Angle k="633.4042134855656" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
-<Angle k="566.8603045200415" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
 <Angle k="441.0116676759102" angle="1.9124271197621583" class1="18" class2="17" class3="33"/>
 <Angle k="441.0116676759102" angle="1.9124271197621583" class1="18" class2="17" class3="34"/>
+<Angle k="302.72200221590714" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="633.4042134855656" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
+<Angle k="566.8603045200415" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
+<Angle k="690.2261815337827" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
 <Angle k="692.4324262826096" angle="2.141228147888421" class1="18" class2="19" class3="20"/>
 <Angle k="267.2688732204102" angle="2.067499239359301" class1="18" class2="19" class3="35"/>
-<Angle k="690.2261815337827" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
 <Angle k="274.32316551133624" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
-<Angle k="340.43451985742695" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
-<Angle k="308.2771278768513" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
-<Angle k="354.75833684494916" angle="1.8733192331827726" class1="27" class2="13" class3="28"/>
-<Angle k="367.6928799885423" angle="1.870916290698717" class1="29" class2="15" class3="30"/>
-<Angle k="298.9762404834261" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
-<Angle k="302.72200221590714" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="672.8043009719439" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
+<Angle k="720.2813544945968" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
+<Angle k="1116.5669365177487" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
+<Angle k="688.132896774631" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
+<Angle k="955.3354720930909" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
+<Angle k="724.0638672794921" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
 </HarmonicAngleForce>
 <PeriodicTorsionForce ordering="smirnoff">
-<Proper k1="9.885128813204e-07" k2="-1.820903915075" k3="2.536745595717" k4="1.515828243391e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="1.123357075731e-06" k2="4.810119186803e-07" k3="1.239122444153" k4="1.523846437582e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="9.885128813204e-07" k2="-1.820903915075" k3="2.536745595717" k4="1.515828243391e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="1.123357075731e-06" k2="4.810119186803e-07" k3="1.239122444153" k4="1.523846437582e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="9.885128813204e-07" k2="-1.820903915075" k3="2.536745595717" k4="1.515828243391e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="1.123357075731e-06" k2="4.810119186803e-07" k3="1.239122444153" k4="1.523846437582e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+<Proper k1="1.011333795e-06" k2="-1.820903449152" k3="2.536749061963" k4="1.906864217568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="8.870344822155e-07" k2="1.81079458274e-07" k3="1.268694596941" k4="2.010437293751e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="1.011333795e-06" k2="-1.820903449152" k3="2.536749061963" k4="1.906864217568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="8.870344822155e-07" k2="1.81079458274e-07" k3="1.268694596941" k4="2.010437293751e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.011333795e-06" k2="-1.820903449152" k3="2.536749061963" k4="1.906864217568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="8.870344822155e-07" k2="1.81079458274e-07" k3="1.268694596941" k4="2.010437293751e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
 </PeriodicTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
 <Atom charge="-0.264836" epsilon="0.2628786511030763" sigma="0.2992019647933705" type="QUBE_0"/>

--- a/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-qforce-ub-rfree.xml
+++ b/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-qforce-ub-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1+18.g864d8cb.dirty" Date="2022_08_25"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -116,318 +116,258 @@
 <Bond from="18" to="21"/>
 <Bond from="19" to="20"/>
 <Bond from="19" to="35"/>
-<Bond from="0" to="2"/>
-<Bond from="0" to="3"/>
-<Bond from="0" to="4"/>
-<Bond from="1" to="5"/>
-<Bond from="1" to="20"/>
-<Bond from="2" to="3"/>
-<Bond from="2" to="4"/>
-<Bond from="3" to="4"/>
-<Bond from="4" to="6"/>
-<Bond from="4" to="22"/>
-<Bond from="4" to="9"/>
-<Bond from="4" to="19"/>
-<Bond from="5" to="20"/>
-<Bond from="5" to="7"/>
-<Bond from="5" to="8"/>
-<Bond from="6" to="22"/>
-<Bond from="6" to="9"/>
-<Bond from="7" to="8"/>
-<Bond from="8" to="10"/>
-<Bond from="8" to="20"/>
-<Bond from="9" to="11"/>
-<Bond from="9" to="21"/>
-<Bond from="9" to="19"/>
-<Bond from="10" to="20"/>
-<Bond from="10" to="12"/>
-<Bond from="10" to="23"/>
-<Bond from="10" to="24"/>
-<Bond from="10" to="14"/>
-<Bond from="10" to="18"/>
-<Bond from="11" to="21"/>
-<Bond from="11" to="13"/>
-<Bond from="11" to="25"/>
-<Bond from="11" to="26"/>
-<Bond from="12" to="23"/>
-<Bond from="12" to="24"/>
-<Bond from="12" to="14"/>
-<Bond from="12" to="27"/>
-<Bond from="12" to="28"/>
-<Bond from="13" to="25"/>
-<Bond from="13" to="26"/>
-<Bond from="13" to="15"/>
-<Bond from="13" to="21"/>
-<Bond from="14" to="27"/>
-<Bond from="14" to="28"/>
-<Bond from="14" to="16"/>
-<Bond from="14" to="29"/>
-<Bond from="14" to="30"/>
-<Bond from="14" to="18"/>
-<Bond from="15" to="21"/>
-<Bond from="15" to="17"/>
-<Bond from="15" to="31"/>
-<Bond from="15" to="32"/>
-<Bond from="16" to="29"/>
-<Bond from="16" to="30"/>
-<Bond from="16" to="18"/>
-<Bond from="16" to="33"/>
-<Bond from="16" to="34"/>
-<Bond from="17" to="31"/>
-<Bond from="17" to="32"/>
-<Bond from="17" to="19"/>
-<Bond from="17" to="21"/>
-<Bond from="18" to="33"/>
-<Bond from="18" to="34"/>
-<Bond from="18" to="20"/>
-<Bond from="18" to="35"/>
-<Bond from="19" to="21"/>
-<Bond from="20" to="35"/>
-<Bond from="23" to="24"/>
-<Bond from="25" to="26"/>
-<Bond from="27" to="28"/>
-<Bond from="29" to="30"/>
-<Bond from="31" to="32"/>
-<Bond from="33" to="34"/>
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13594155463667298" k="218345.11400156797" class1="0" class2="1"/>
-<Bond length="0.13594155463667298" k="218345.11400156797" class1="1" class2="2"/>
-<Bond length="0.13594155463667298" k="218345.11400156797" class1="1" class2="3"/>
-<Bond length="0.14770475272616868" k="197821.41121542244" class1="1" class2="4"/>
-<Bond length="0.13961052875885102" k="347701.6372554976" class1="4" class2="5"/>
-<Bond length="0.1442192930696654" k="188115.78910600924" class1="4" class2="20"/>
-<Bond length="0.14223091098938934" k="282728.98159665783" class1="5" class2="6"/>
-<Bond length="0.10822001583405008" k="334179.22835574934" class1="5" class2="22"/>
-<Bond length="0.12173305755747404" k="631666.2297066626" class1="6" class2="7"/>
-<Bond length="0.14175110272148425" k="110405.87619007888" class1="6" class2="8"/>
-<Bond length="0.13571416599367517" k="266059.6263586127" class1="8" class2="9"/>
-<Bond length="0.1382083808080489" k="315979.76337889826" class1="9" class2="10"/>
-<Bond length="0.142453038842533" k="192643.42066530464" class1="9" class2="20"/>
-<Bond length="0.15060063293211423" k="198442.54930400208" class1="10" class2="11"/>
-<Bond length="0.14258713560769964" k="214352.20100677275" class1="10" class2="21"/>
-<Bond length="0.15227572432554826" k="189630.63541166234" class1="11" class2="12"/>
-<Bond length="0.10958672840190148" k="296812.7528608025" class1="11" class2="23"/>
-<Bond length="0.10958672840190148" k="296812.7528608025" class1="11" class2="24"/>
-<Bond length="0.1519270774055388" k="187828.9795065073" class1="12" class2="13"/>
-<Bond length="0.10952500777673012" k="300522.66316489165" class1="12" class2="25"/>
-<Bond length="0.10952500777673012" k="300522.66316489165" class1="12" class2="26"/>
-<Bond length="0.14565680593432032" k="190940.15357437066" class1="13" class2="14"/>
-<Bond length="0.10983719228431021" k="290564.0324418536" class1="13" class2="27"/>
-<Bond length="0.10983719228431021" k="290564.0324418536" class1="13" class2="28"/>
-<Bond length="0.14565680593432032" k="190940.15357437066" class1="14" class2="15"/>
-<Bond length="0.1369783820752729" k="293678.32159396494" class1="14" class2="21"/>
-<Bond length="0.15193935490482638" k="188791.05826691588" class1="15" class2="16"/>
-<Bond length="0.10983719228431021" k="290564.0324418536" class1="15" class2="29"/>
-<Bond length="0.10983719228431021" k="290564.0324418536" class1="15" class2="30"/>
-<Bond length="0.1523142800205355" k="188957.9189734324" class1="16" class2="17"/>
-<Bond length="0.10952502935011754" k="300643.5069172258" class1="16" class2="31"/>
-<Bond length="0.10952502935011754" k="300643.5069172258" class1="16" class2="32"/>
-<Bond length="0.15063936367015732" k="203356.81424712564" class1="17" class2="18"/>
-<Bond length="0.10969834880306709" k="293229.6714246237" class1="17" class2="33"/>
-<Bond length="0.10969834880306709" k="293229.6714246237" class1="17" class2="34"/>
-<Bond length="0.1376230871323796" k="328332.2395981214" class1="18" class2="19"/>
-<Bond length="0.14311745649268223" k="212981.29225777485" class1="18" class2="21"/>
-<Bond length="0.14157012681086414" k="237890.65634907247" class1="19" class2="20"/>
-<Bond length="0.10836619841427811" k="333035.86840816936" class1="19" class2="35"/>
-<Bond length="0.21689078360673025" k="64150.468898069696" class1="0" class2="2"/>
-<Bond length="0.21689078360673025" k="64150.468898069696" class1="0" class2="3"/>
-<Bond length="0.2364864474629915" k="41325.70122505751" class1="0" class2="4"/>
-<Bond length="0.25017868954369815" k="10978.933967677776" class1="1" class2="5"/>
-<Bond length="0.2534860324725394" k="61252.768063914526" class1="1" class2="20"/>
-<Bond length="0.21689078360673025" k="64150.468898069696" class1="2" class2="3"/>
-<Bond length="0.2364864474629915" k="41325.70122505751" class1="2" class2="4"/>
-<Bond length="0.2364864474629915" k="41325.70122505751" class1="3" class2="4"/>
-<Bond length="0.24782238837806544" k="27384.38049993946" class1="4" class2="6"/>
-<Bond length="0.2165030574017915" k="12551.263561941327" class1="4" class2="22"/>
-<Bond length="0.2455736310625806" k="46545.96892840459" class1="4" class2="9"/>
-<Bond length="0.2537722246826899" k="33434.42030216432" class1="4" class2="19"/>
-<Bond length="0.24378442341267956" k="48850.363944896126" class1="5" class2="20"/>
-<Bond length="0.23745488882021154" k="61647.127379274025" class1="5" class2="7"/>
-<Bond length="0.2416757937731322" k="43445.11020825616" class1="5" class2="8"/>
-<Bond length="0.21275502134276836" k="18798.38777198013" class1="6" class2="22"/>
-<Bond length="0.2423514965995231" k="46214.354447836704" class1="6" class2="9"/>
-<Bond length="0.2228657733109233" k="79174.34448327207" class1="7" class2="8"/>
-<Bond length="0.23151894390905997" k="62928.04972839788" class1="8" class2="10"/>
-<Bond length="0.24339480040217093" k="30513.387060955734" class1="8" class2="20"/>
-<Bond length="0.24975022931680144" k="19694.335516354855" class1="9" class2="11"/>
-<Bond length="0.24187092582637876" k="38800.45429412608" class1="9" class2="21"/>
-<Bond length="0.24201627686067356" k="52390.16248378882" class1="9" class2="19"/>
-<Bond length="0.24612569405012136" k="42849.69604268449" class1="10" class2="20"/>
-<Bond length="0.24991111909979238" k="21501.701255650205" class1="10" class2="12"/>
-<Bond length="0.21364058799943095" k="18803.253755304686" class1="10" class2="23"/>
-<Bond length="0.21364058799943095" k="18803.253755304686" class1="10" class2="24"/>
-<Bond length="0.2420248299327458" k="48951.862766363214" class1="10" class2="14"/>
-<Bond length="0.24712865951164575" k="50242.90717196352" class1="10" class2="18"/>
-<Bond length="0.25572586399439895" k="18041.795340807555" class1="11" class2="21"/>
-<Bond length="0.24901456266768196" k="32321.892480841558" class1="11" class2="13"/>
-<Bond length="0.2165189488422092" k="10961.335868820766" class1="11" class2="25"/>
-<Bond length="0.2165189488422092" k="10961.335868820766" class1="11" class2="26"/>
-<Bond length="0.21661802925246812" k="11768.302947215923" class1="12" class2="23"/>
-<Bond length="0.21661802925246812" k="11768.302947215923" class1="12" class2="24"/>
-<Bond length="0.2454186379331869" k="34460.258480345656" class1="12" class2="14"/>
-<Bond length="0.21661401961453586" k="11992.462249555532" class1="12" class2="27"/>
-<Bond length="0.21661401961453586" k="11992.462249555532" class1="12" class2="28"/>
-<Bond length="0.21452792982373092" k="13180.64807495115" class1="13" class2="25"/>
-<Bond length="0.21452792982373092" k="13180.64807495115" class1="13" class2="26"/>
-<Bond length="0.24778380868952166" k="5543.670520609479" class1="13" class2="15"/>
-<Bond length="0.24586309792299157" k="24864.586199049343" class1="13" class2="21"/>
-<Bond length="0.20836612491682935" k="23466.26972290285" class1="14" class2="27"/>
-<Bond length="0.20836612491682935" k="23466.26972290285" class1="14" class2="28"/>
-<Bond length="0.24612101687514346" k="32957.858378232544" class1="14" class2="16"/>
-<Bond length="0.20836612491682935" k="23466.26972290285" class1="14" class2="29"/>
-<Bond length="0.20836612491682935" k="23466.26972290285" class1="14" class2="30"/>
-<Bond length="0.24297788191575906" k="46787.25464187675" class1="14" class2="18"/>
-<Bond length="0.24586309792299157" k="24864.586199049343" class1="15" class2="21"/>
-<Bond length="0.24828371990244094" k="31499.066957938514" class1="15" class2="17"/>
-<Bond length="0.21464121187011923" k="13402.490415193673" class1="15" class2="31"/>
-<Bond length="0.21464121187011923" k="13402.490415193673" class1="15" class2="32"/>
-<Bond length="0.21644638235158423" k="11184.008271776363" class1="16" class2="29"/>
-<Bond length="0.21644638235158423" k="11184.008271776363" class1="16" class2="30"/>
-<Bond length="0.2496339349142613" k="21935.21374749977" class1="16" class2="18"/>
-<Bond length="0.21617620291307876" k="12396.753533611565" class1="16" class2="33"/>
-<Bond length="0.21617620291307876" k="12396.753533611565" class1="16" class2="34"/>
-<Bond length="0.21671848266256852" k="10882.634616066494" class1="17" class2="31"/>
-<Bond length="0.21671848266256852" k="10882.634616066494" class1="17" class2="32"/>
-<Bond length="0.25035622871790025" k="18033.112456227183" class1="17" class2="19"/>
-<Bond length="0.25484547528105317" k="16889.732908794533" class1="17" class2="21"/>
-<Bond length="0.21400564848019982" k="17730.513374911174" class1="18" class2="33"/>
-<Bond length="0.21400564848019982" k="17730.513374911174" class1="18" class2="34"/>
-<Bond length="0.2449980098005106" k="61827.57357252558" class1="18" class2="20"/>
-<Bond length="0.21188905925070795" k="10002.703317301359" class1="18" class2="35"/>
-<Bond length="0.24211627925518933" k="45696.33561677619" class1="19" class2="21"/>
-<Bond length="0.21585169241853103" k="7599.027743563363" class1="20" class2="35"/>
-<Bond length="0.17455161176521647" k="14218.179700885103" class1="23" class2="24"/>
-<Bond length="0.17659145737057533" k="13479.586829962293" class1="25" class2="26"/>
-<Bond length="0.1768878357199081" k="13479.320031697353" class1="27" class2="28"/>
-<Bond length="0.1768878357199081" k="13479.320031697353" class1="29" class2="30"/>
-<Bond length="0.17669982064045128" k="13319.71336753191" class1="31" class2="32"/>
-<Bond length="0.17561999811379547" k="14154.211681113764" class1="33" class2="34"/>
+<Bond length="0.13594155463667298" k="218345.1140015796" class1="0" class2="1"/>
+<Bond length="0.13594155463667298" k="218345.1140015796" class1="1" class2="2"/>
+<Bond length="0.13594155463667298" k="218345.1140015796" class1="1" class2="3"/>
+<Bond length="0.14770475272616868" k="197821.4112154328" class1="1" class2="4"/>
+<Bond length="0.13961052875885102" k="347701.6372554986" class1="4" class2="5"/>
+<Bond length="0.14421929306966538" k="188115.78910600618" class1="4" class2="20"/>
+<Bond length="0.1422309109893893" k="282728.9815966565" class1="5" class2="6"/>
+<Bond length="0.10822001583405005" k="334179.2283557531" class1="5" class2="22"/>
+<Bond length="0.12173305755747404" k="631666.2297066611" class1="6" class2="7"/>
+<Bond length="0.14175110272148425" k="110405.87619008074" class1="6" class2="8"/>
+<Bond length="0.1357141659936751" k="266059.6263586112" class1="8" class2="9"/>
+<Bond length="0.13820838080804893" k="315979.76337889594" class1="9" class2="10"/>
+<Bond length="0.14245303884253296" k="192643.42066531253" class1="9" class2="20"/>
+<Bond length="0.15060063293211423" k="198442.54930400875" class1="10" class2="11"/>
+<Bond length="0.14258713560769973" k="214352.20100676248" class1="10" class2="21"/>
+<Bond length="0.1522757243255483" k="189630.63541165853" class1="11" class2="12"/>
+<Bond length="0.10958672840190148" k="296812.7528608085" class1="11" class2="23"/>
+<Bond length="0.10958672840190148" k="296812.7528608085" class1="11" class2="24"/>
+<Bond length="0.1519270774055388" k="187828.97950651828" class1="12" class2="13"/>
+<Bond length="0.10952500777673013" k="300522.6631648919" class1="12" class2="25"/>
+<Bond length="0.10952500777673013" k="300522.6631648919" class1="12" class2="26"/>
+<Bond length="0.14565680593432032" k="190940.1535743786" class1="13" class2="14"/>
+<Bond length="0.10983719228431021" k="290564.0324418495" class1="13" class2="27"/>
+<Bond length="0.10983719228431021" k="290564.0324418495" class1="13" class2="28"/>
+<Bond length="0.14565680593432032" k="190940.1535743786" class1="14" class2="15"/>
+<Bond length="0.13697838207527296" k="293678.32159396424" class1="14" class2="21"/>
+<Bond length="0.15193935490482638" k="188791.05826691442" class1="15" class2="16"/>
+<Bond length="0.10983719228431021" k="290564.0324418495" class1="15" class2="29"/>
+<Bond length="0.10983719228431021" k="290564.0324418495" class1="15" class2="30"/>
+<Bond length="0.1523142800205355" k="188957.91897343635" class1="16" class2="17"/>
+<Bond length="0.10952502935011754" k="300643.5069172228" class1="16" class2="31"/>
+<Bond length="0.10952502935011754" k="300643.5069172228" class1="16" class2="32"/>
+<Bond length="0.1506393636701573" k="203356.81424711348" class1="17" class2="18"/>
+<Bond length="0.10969834880306709" k="293229.67142462" class1="17" class2="33"/>
+<Bond length="0.10969834880306709" k="293229.67142462" class1="17" class2="34"/>
+<Bond length="0.1376230871323796" k="328332.2395981151" class1="18" class2="19"/>
+<Bond length="0.14311745649268223" k="212981.29225777328" class1="18" class2="21"/>
+<Bond length="0.14157012681086414" k="237890.65634907514" class1="19" class2="20"/>
+<Bond length="0.10836619841427811" k="333035.86840816675" class1="19" class2="35"/>
 </HarmonicBondForce>
 <HarmonicAngleForce>
-<Angle k="612.576705517581" angle="1.8470606834084642" class1="0" class2="1" class3="2"/>
-<Angle k="612.576705517581" angle="1.8470606834084642" class1="0" class2="1" class3="3"/>
-<Angle k="494.9558337882429" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
-<Angle k="461.41478257238975" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
-<Angle k="161.11512319910696" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
-<Angle k="612.576705517581" angle="1.8470606834084642" class1="2" class2="1" class3="3"/>
-<Angle k="494.9558337882429" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
-<Angle k="494.9558337882429" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
-<Angle k="445.6722338395139" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
-<Angle k="234.39752573273313" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
-<Angle k="646.874219182729" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
-<Angle k="661.2645982954376" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
-<Angle k="220.200553009088" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
-<Angle k="56.23447229956712" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
-<Angle k="195.78553601228472" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
-<Angle k="478.7196400311802" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
-<Angle k="753.6839310253774" angle="2.0126223566140804" class1="7" class2="6" class3="8"/>
-<Angle k="537.382518092639" angle="2.013820749887496" class1="8" class2="9" class3="10"/>
-<Angle k="292.0223526763972" angle="2.130524412137124" class1="8" class2="9" class3="20"/>
-<Angle k="299.68844386020606" angle="2.0882702117790397" class1="9" class2="10" class3="11"/>
-<Angle k="316.4381888078996" angle="2.075806905333667" class1="9" class2="10" class3="21"/>
-<Angle k="165.94522508406334" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
-<Angle k="189.3349010616362" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
-<Angle k="412.20213139089714" angle="1.9408289971728419" class1="10" class2="11" class3="12"/>
-<Angle k="295.61337602420696" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
-<Angle k="295.61337602420696" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
-<Angle k="475.00701165169085" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
-<Angle k="190.03127558509172" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
-<Angle k="430.8783316123277" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
-<Angle k="594.7950268399549" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
-<Angle k="353.7696990152278" angle="1.9290790266726685" class1="11" class2="12" class3="25"/>
-<Angle k="353.7696990152278" angle="1.9290790266726685" class1="11" class2="12" class3="26"/>
-<Angle k="342.17462093106286" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
-<Angle k="342.17462093106286" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
-<Angle k="537.4806833752626" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
-<Angle k="331.60110868830594" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
-<Angle k="331.60110868830594" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
-<Angle k="339.9744992155158" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
-<Angle k="339.9744992155158" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
-<Angle k="555.7812602100205" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
-<Angle k="334.60398229432235" angle="2.109446108796937" class1="13" class2="14" class3="21"/>
-<Angle k="365.69530312991526" angle="1.8931388133109963" class1="14" class2="13" class3="27"/>
-<Angle k="365.69530312991526" angle="1.8931388133109963" class1="14" class2="13" class3="28"/>
-<Angle k="541.5611987054602" angle="1.9473052141515759" class1="14" class2="15" class3="16"/>
-<Angle k="365.69530312991526" angle="1.8931388133109963" class1="14" class2="15" class3="29"/>
-<Angle k="365.69530312991526" angle="1.8931388133109963" class1="14" class2="15" class3="30"/>
-<Angle k="583.5905181902485" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
-<Angle k="334.60398229432235" angle="2.109446108796937" class1="15" class2="14" class3="21"/>
-<Angle k="589.9703830672662" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
-<Angle k="344.3588496535696" angle="1.9073030765505146" class1="15" class2="16" class3="31"/>
-<Angle k="344.3588496535696" angle="1.9073030765505146" class1="15" class2="16" class3="32"/>
-<Angle k="340.30102246430073" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
-<Angle k="340.30102246430073" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
-<Angle k="417.5897592266575" angle="1.9368504917581066" class1="16" class2="17" class3="18"/>
-<Angle k="345.389626967739" angle="1.922073455348455" class1="16" class2="17" class3="33"/>
-<Angle k="345.389626967739" angle="1.922073455348455" class1="16" class2="17" class3="34"/>
-<Angle k="356.14559180359083" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
-<Angle k="356.14559180359083" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
-<Angle k="513.3712786680062" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
-<Angle k="376.15658971581746" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
-<Angle k="292.7525862777635" angle="1.9124271197621583" class1="18" class2="17" class3="33"/>
-<Angle k="292.7525862777635" angle="1.9124271197621583" class1="18" class2="17" class3="34"/>
-<Angle k="351.90822125450944" angle="2.141228147888421" class1="18" class2="19" class3="20"/>
-<Angle k="263.94530012636744" angle="2.067499239359301" class1="18" class2="19" class3="35"/>
-<Angle k="252.73272276957562" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
-<Angle k="261.95384711791866" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
-<Angle k="253.80923337819542" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
-<Angle k="267.7120145269162" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
-<Angle k="253.3089187229781" angle="1.8721177619407448" class1="27" class2="13" class3="28"/>
-<Angle k="253.3089187229781" angle="1.8721177619407448" class1="29" class2="15" class3="30"/>
-<Angle k="265.47936477879466" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
-<Angle k="264.940016739506" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="612.5767055176452" angle="1.8470606834084646" class1="0" class2="1" class3="2"/>
+<Angle k="612.5767055176452" angle="1.8470606834084646" class1="0" class2="1" class3="3"/>
+<Angle k="494.95583378801535" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
+<Angle k="461.41478257245404" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
+<Angle k="161.11512319918518" angle="2.103564008373859" class1="1" class2="4" class3="20"/>
+<Angle k="612.5767055176452" angle="1.8470606834084646" class1="2" class2="1" class3="3"/>
+<Angle k="494.95583378801535" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
+<Angle k="494.95583378801535" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
+<Angle k="445.67223383952097" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
+<Angle k="234.39752573269794" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
+<Angle k="646.8742191827558" angle="2.0574014490279273" class1="4" class2="20" class3="9"/>
+<Angle k="661.2645982954101" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
+<Angle k="5.681105893004315e-29" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
+<Angle k="220.20055300915106" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
+<Angle k="56.234472299433435" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
+<Angle k="195.78553601230666" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
+<Angle k="478.7196400313228" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
+<Angle k="753.683931025259" angle="2.01262235661408" class1="7" class2="6" class3="8"/>
+<Angle k="537.3825180924109" angle="2.0138207498874956" class1="8" class2="9" class3="10"/>
+<Angle k="292.02235267633085" angle="2.1305244121371243" class1="8" class2="9" class3="20"/>
+<Angle k="299.68844386055866" angle="2.08827021177904" class1="9" class2="10" class3="11"/>
+<Angle k="316.43818880785886" angle="2.0758069053336667" class1="9" class2="10" class3="21"/>
+<Angle k="165.94522508413007" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
+<Angle k="189.33490106163478" angle="2.1388266176337605" class1="10" class2="9" class3="20"/>
+<Angle k="412.2021313904744" angle="1.9408289971728416" class1="10" class2="11" class3="12"/>
+<Angle k="295.6133760240494" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
+<Angle k="295.6133760240494" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
+<Angle k="475.00701165163093" angle="2.092932336208997" class1="10" class2="21" class3="14"/>
+<Angle k="190.03127558498662" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
+<Angle k="430.878331612601" angle="2.119049411398643" class1="11" class2="10" class3="21"/>
+<Angle k="594.7950268401472" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
+<Angle k="353.76969901539513" angle="1.9290790266726683" class1="11" class2="12" class3="25"/>
+<Angle k="353.76969901539513" angle="1.9290790266726683" class1="11" class2="12" class3="26"/>
+<Angle k="342.17462093127796" angle="1.9298086029005783" class1="12" class2="11" class3="23"/>
+<Angle k="342.17462093127796" angle="1.9298086029005783" class1="12" class2="11" class3="24"/>
+<Angle k="537.4806833755054" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
+<Angle k="331.6011086881617" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
+<Angle k="331.6011086881617" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
+<Angle k="339.97449921545433" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
+<Angle k="339.97449921545433" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
+<Angle k="555.7812602100458" angle="2.034152095003215" class1="13" class2="14" class3="15"/>
+<Angle k="334.60398229430587" angle="2.109446108796937" class1="13" class2="14" class3="21"/>
+<Angle k="365.69530312999603" angle="1.8931388133109963" class1="14" class2="13" class3="27"/>
+<Angle k="365.69530312999603" angle="1.8931388133109963" class1="14" class2="13" class3="28"/>
+<Angle k="541.5611987055723" angle="1.9473052141515765" class1="14" class2="15" class3="16"/>
+<Angle k="365.69530312999603" angle="1.8931388133109963" class1="14" class2="15" class3="29"/>
+<Angle k="365.69530312999603" angle="1.8931388133109963" class1="14" class2="15" class3="30"/>
+<Angle k="583.5905181903241" angle="2.0999575687247725" class1="14" class2="21" class3="18"/>
+<Angle k="334.60398229430587" angle="2.109446108796937" class1="15" class2="14" class3="21"/>
+<Angle k="589.9703830671508" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
+<Angle k="344.3588496535635" angle="1.9073030765505143" class1="15" class2="16" class3="31"/>
+<Angle k="344.3588496535635" angle="1.9073030765505143" class1="15" class2="16" class3="32"/>
+<Angle k="340.3010224642744" angle="1.928919061549237" class1="16" class2="15" class3="29"/>
+<Angle k="340.3010224642744" angle="1.928919061549237" class1="16" class2="15" class3="30"/>
+<Angle k="417.5897592268539" angle="1.9368504917581069" class1="16" class2="17" class3="18"/>
+<Angle k="345.3896269677175" angle="1.9220734553484546" class1="16" class2="17" class3="33"/>
+<Angle k="345.3896269677175" angle="1.9220734553484546" class1="16" class2="17" class3="34"/>
+<Angle k="356.1455918035348" angle="1.9313757859816714" class1="17" class2="16" class3="31"/>
+<Angle k="356.1455918035348" angle="1.9313757859816714" class1="17" class2="16" class3="32"/>
+<Angle k="513.3712786679531" angle="2.103174723548534" class1="17" class2="18" class3="19"/>
+<Angle k="376.1565897157043" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
+<Angle k="292.75258627783586" angle="1.912427119762158" class1="18" class2="17" class3="33"/>
+<Angle k="292.75258627783586" angle="1.912427119762158" class1="18" class2="17" class3="34"/>
+<Angle k="351.9082212544887" angle="2.1412281478884214" class1="18" class2="19" class3="20"/>
+<Angle k="263.9453001263889" angle="2.0674992393593006" class1="18" class2="19" class3="35"/>
+<Angle k="252.73272276957775" angle="2.0798377077856456" class1="19" class2="18" class3="21"/>
+<Angle k="261.9538471178965" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
+<Angle k="253.80923337821767" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
+<Angle k="267.7120145268549" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
+<Angle k="253.30891872296334" angle="1.8721177619407448" class1="27" class2="13" class3="28"/>
+<Angle k="253.30891872296334" angle="1.8721177619407448" class1="29" class2="15" class3="30"/>
+<Angle k="265.479364778801" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
+<Angle k="264.94001673948657" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce>
+<UreyBradley k="32075.234449032752" d="0.2168907836067303" class1="0" class2="1" class3="2"/>
+<UreyBradley k="32075.234449032752" d="0.2168907836067303" class1="0" class2="1" class3="3"/>
+<UreyBradley k="20662.850612521845" d="0.2364864474629915" class1="0" class2="1" class3="4"/>
+<UreyBradley k="5489.466983840552" d="0.25017868954369815" class1="1" class2="4" class3="5"/>
+<UreyBradley k="30626.38403195799" d="0.2534860324725394" class1="1" class2="4" class3="20"/>
+<UreyBradley k="32075.234449032752" d="0.2168907836067303" class1="2" class2="1" class3="3"/>
+<UreyBradley k="20662.850612521845" d="0.2364864474629915" class1="2" class2="1" class3="4"/>
+<UreyBradley k="20662.850612521845" d="0.2364864474629915" class1="3" class2="1" class3="4"/>
+<UreyBradley k="13692.190249971438" d="0.2478223883780654" class1="4" class2="5" class3="6"/>
+<UreyBradley k="6275.631780969946" d="0.2165030574017915" class1="4" class2="5" class3="22"/>
+<UreyBradley k="23272.98446420542" d="0.24557363106258057" class1="4" class2="20" class3="9"/>
+<UreyBradley k="16717.210151079977" d="0.25377222468268984" class1="4" class2="20" class3="19"/>
+<UreyBradley k="24425.181972448438" d="0.2437844234126795" class1="5" class2="4" class3="20"/>
+<UreyBradley k="30823.563689635444" d="0.23745488882021154" class1="5" class2="6" class3="7"/>
+<UreyBradley k="21722.555104125848" d="0.24167579377313217" class1="5" class2="6" class3="8"/>
+<UreyBradley k="9399.193885990895" d="0.2127550213427683" class1="6" class2="5" class3="22"/>
+<UreyBradley k="23107.177223919098" d="0.24235149659952304" class1="6" class2="8" class3="9"/>
+<UreyBradley k="39587.17224163388" d="0.2228657733109233" class1="7" class2="6" class3="8"/>
+<UreyBradley k="31464.024864197312" d="0.23151894390905992" class1="8" class2="9" class3="10"/>
+<UreyBradley k="15256.693530476621" d="0.24339480040217087" class1="8" class2="9" class3="20"/>
+<UreyBradley k="9847.167758181442" d="0.24975022931680146" class1="9" class2="10" class3="11"/>
+<UreyBradley k="19400.227147063633" d="0.2418709258263788" class1="9" class2="10" class3="21"/>
+<UreyBradley k="26195.081241894644" d="0.2420162768606735" class1="9" class2="20" class3="19"/>
+<UreyBradley k="21424.848021340127" d="0.24612569405012136" class1="10" class2="9" class3="20"/>
+<UreyBradley k="10750.850627819054" d="0.24991111909979238" class1="10" class2="11" class3="12"/>
+<UreyBradley k="9401.6268776481" d="0.2136405879994309" class1="10" class2="11" class3="23"/>
+<UreyBradley k="9401.6268776481" d="0.2136405879994309" class1="10" class2="11" class3="24"/>
+<UreyBradley k="24475.931383183637" d="0.24202482993274588" class1="10" class2="21" class3="14"/>
+<UreyBradley k="25121.453585981544" d="0.2471286595116458" class1="10" class2="21" class3="18"/>
+<UreyBradley k="9020.897670412176" d="0.255725863994399" class1="11" class2="10" class3="21"/>
+<UreyBradley k="16160.946240433012" d="0.24901456266768196" class1="11" class2="12" class3="13"/>
+<UreyBradley k="5480.667934401025" d="0.21651894884220924" class1="11" class2="12" class3="25"/>
+<UreyBradley k="5480.667934401025" d="0.21651894884220924" class1="11" class2="12" class3="26"/>
+<UreyBradley k="5884.151473603568" d="0.21661802925246817" class1="12" class2="11" class3="23"/>
+<UreyBradley k="5884.151473603568" d="0.21661802925246817" class1="12" class2="11" class3="24"/>
+<UreyBradley k="17230.12924017668" d="0.2454186379331869" class1="12" class2="13" class3="14"/>
+<UreyBradley k="5996.231124783206" d="0.21661401961453586" class1="12" class2="13" class3="27"/>
+<UreyBradley k="5996.231124783206" d="0.21661401961453586" class1="12" class2="13" class3="28"/>
+<UreyBradley k="6590.324037479275" d="0.21452792982373092" class1="13" class2="12" class3="25"/>
+<UreyBradley k="6590.324037479275" d="0.21452792982373092" class1="13" class2="12" class3="26"/>
+<UreyBradley k="2771.8352603020367" d="0.2477838086895217" class1="13" class2="14" class3="15"/>
+<UreyBradley k="12432.293099516339" d="0.24586309792299163" class1="13" class2="14" class3="21"/>
+<UreyBradley k="11733.134861452327" d="0.20836612491682935" class1="14" class2="13" class3="27"/>
+<UreyBradley k="11733.134861452327" d="0.20836612491682935" class1="14" class2="13" class3="28"/>
+<UreyBradley k="16478.92918911497" d="0.2461210168751435" class1="14" class2="15" class3="16"/>
+<UreyBradley k="11733.134861452327" d="0.20836612491682935" class1="14" class2="15" class3="29"/>
+<UreyBradley k="11733.134861452327" d="0.20836612491682935" class1="14" class2="15" class3="30"/>
+<UreyBradley k="23393.6273209368" d="0.24297788191575914" class1="14" class2="21" class3="18"/>
+<UreyBradley k="12432.293099516339" d="0.24586309792299163" class1="15" class2="14" class3="21"/>
+<UreyBradley k="15749.533478969517" d="0.24828371990244094" class1="15" class2="16" class3="17"/>
+<UreyBradley k="6701.245207597083" d="0.21464121187011923" class1="15" class2="16" class3="31"/>
+<UreyBradley k="6701.245207597083" d="0.21464121187011923" class1="15" class2="16" class3="32"/>
+<UreyBradley k="5592.004135889347" d="0.21644638235158423" class1="16" class2="15" class3="29"/>
+<UreyBradley k="5592.004135889347" d="0.21644638235158423" class1="16" class2="15" class3="30"/>
+<UreyBradley k="10967.606873761884" d="0.24963393491426134" class1="16" class2="17" class3="18"/>
+<UreyBradley k="6198.376766806298" d="0.2161762029130787" class1="16" class2="17" class3="33"/>
+<UreyBradley k="6198.376766806298" d="0.2161762029130787" class1="16" class2="17" class3="34"/>
+<UreyBradley k="5441.3173080342285" d="0.21671848266256852" class1="17" class2="16" class3="31"/>
+<UreyBradley k="5441.3173080342285" d="0.21671848266256852" class1="17" class2="16" class3="32"/>
+<UreyBradley k="9016.556228114574" d="0.2503562287179003" class1="17" class2="18" class3="19"/>
+<UreyBradley k="8444.866454393494" d="0.2548454752810531" class1="17" class2="18" class3="21"/>
+<UreyBradley k="8865.256687456214" d="0.21400564848019976" class1="18" class2="17" class3="33"/>
+<UreyBradley k="8865.256687456214" d="0.21400564848019976" class1="18" class2="17" class3="34"/>
+<UreyBradley k="30913.786786259196" d="0.2449980098005106" class1="18" class2="19" class3="20"/>
+<UreyBradley k="5001.351658651864" d="0.21188905925070795" class1="18" class2="19" class3="35"/>
+<UreyBradley k="22848.167808385206" d="0.2421162792551893" class1="19" class2="18" class3="21"/>
+<UreyBradley k="3799.51387178256" d="0.21585169241853103" class1="20" class2="19" class3="35"/>
+<UreyBradley k="7109.089850441461" d="0.17455161176521647" class1="23" class2="11" class3="24"/>
+<UreyBradley k="6739.793414983314" d="0.17659145737057536" class1="25" class2="12" class3="26"/>
+<UreyBradley k="6739.660015848941" d="0.1768878357199081" class1="27" class2="13" class3="28"/>
+<UreyBradley k="6739.660015848941" d="0.1768878357199081" class1="29" class2="15" class3="30"/>
+<UreyBradley k="6659.856683766629" d="0.17669982064045128" class1="31" class2="16" class3="32"/>
+<UreyBradley k="7077.105840557829" d="0.17561999811379547" class1="33" class2="17" class3="34"/>
+</AmoebaUreyBradleyForce>
 <PeriodicTorsionForce ordering="charmm">
-<Proper k1="1.246410883412e-06" k2="-1.82090360157" k3="0.5477854586104" k4="2.004472538548e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="6.999177498183e-07" k2="1.081830506926e-06" k3="-0.173102996515" k4="1.231780411642e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="7.097390468351821" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="1.246410883412e-06" k2="-1.82090360157" k3="0.5477854586104" k4="2.004472538548e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="6.999177498183e-07" k2="1.081830506926e-06" k3="-0.173102996515" k4="1.231780411642e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="1.246410883412e-06" k2="-1.82090360157" k3="0.5477854586104" k4="2.004472538548e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="6.999177498183e-07" k2="1.081830506926e-06" k3="-0.173102996515" k4="1.231780411642e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="41.77318731410394" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="27.897746492945917" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="21.806068276966666" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="17.19577984997331" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="16.058038752077525" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.72362662732526" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="6.416239171572119" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="23.00797375986259" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="33.28093437424742" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="4.12886883521308" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="17.66424660990424" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="26.353976842616106" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="20.124816873932897" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="12.92136512719599" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="5.500045380243782" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="19.716353976816453" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="18.4465294491972" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="10.376754686433685" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="3.678199315079189" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="42.81969520029169" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="37.91938785408229" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="32.44256114987371" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="12.653430041411609" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="28.958210384288183" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="9.487513916030489" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="16.79158303940065" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.51957497306686" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.3870255928972009" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="18.847912229465674" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="12.09492758755026" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="14.247728873897653" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="10.480137473982039" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="1.819054040963526e-22" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="5.121088506099645e-26" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="3.137906997404916e-25" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="1.2577519895394398e-29" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="1.020849221917508e-24" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="7.097390468340361" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="5.278003272762256e-27" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="6.46696454333553e-29" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="41.77318731443608" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="27.897746493435864" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="33.28093437439758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="17.6642466092395" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="6.416239172130124" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="4.128868836006963" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="23.007973760158087" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="7.623435078627158e-25" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="26.353976842374166" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="1.2738987118269488e-08" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="32.44256114970877" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="14.247728873898065" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="21.80606827676723" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="20.124816873224546" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="17.195779849986163" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="10.37675468648307" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="9.48751391561695" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="12.921365127295491" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="5.500045380304658" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="12.65343004207149" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="28.958210384591485" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="3.678199314636092" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="10"/>
+<Proper k1="0" k2="0.3870255928011037" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="18.847912229628264" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="12.094927587454372" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="5.955379833333655e-29" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="10.480137473832992" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="42.819695199985865" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="16.79158303954128" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="37.91938785385325" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="15.519574973031805" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="16.05803875211824" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="19.71635397690738" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="9"/>
+<Proper k1="0" k2="15.723626627381211" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="18.44652944932921" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="9"/>
+<Proper k1="1.161732269289e-06" k2="-1.820903316568" k3="0.7144443090864" k4="2.346456590036e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="7.604778996518e-07" k2="9.055972927087e-07" k3="-0.1731044200671" k4="1.590036981568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="1.161732269289e-06" k2="-1.820903316568" k3="0.7144443090864" k4="2.346456590036e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="7.604778996518e-07" k2="9.055972927087e-07" k3="-0.1731044200671" k4="1.590036981568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.161732269289e-06" k2="-1.820903316568" k3="0.7144443090864" k4="2.346456590036e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="7.604778996518e-07" k2="9.055972927087e-07" k3="-0.1731044200671" k4="1.590036981568e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
 </PeriodicTorsionForce>
 <RBTorsionForce>
-<Proper c0="12.499" c1="37.438" c2="28.034" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
-<Proper c0="21.863" c1="82.037" c2="76.958" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
-<Proper c0="27.154" c1="69.958" c2="45.058" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
-<Proper c0="24.508" c1="89.725" c2="82.12" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
-<Proper c0="4.312" c1="13.877" c2="11.165" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
-<Proper c0="35.953" c1="87.611" c2="53.372" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
-<Proper c0="128.913" c1="285.074" c2="157.6" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="17" class3="18" class4="21"/>
+<Proper c0="12.499" c1="37.438" c2="28.034" c3="0" c4="0" c5="0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.863" c1="82.037" c2="76.958" c3="0" c4="0" c5="0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="27.154" c1="69.958" c2="45.058" c3="0" c4="0" c5="0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="35.953" c1="87.611" c2="53.372" c3="0" c4="0" c5="0" class1="21" class2="14" class3="15" class4="16"/>
+<Proper c0="24.508" c1="89.725" c2="82.12" c3="0" c4="0" c5="0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="4.312" c1="13.877" c2="11.165" c3="0" c4="0" c5="0" class1="15" class2="16" class3="17" class4="18"/>
+<Proper c0="128.913" c1="285.074" c2="157.6" c3="0" c4="0" c5="0" class1="16" class2="17" class3="18" class4="21"/>
 </RBTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
 <Atom charge="-0.264836" epsilon="0.2628786511030763" sigma="0.2992019647933705" type="QUBE_0"/>

--- a/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-sites-modsem-rfree.xml
+++ b/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-sites-modsem-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1+18.g864d8cb.dirty" Date="2022_08_25"/>
+<QUBEKit Version="2.1.1+27.gac67d93.dirty" Date="2022_10_11"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -125,9 +125,9 @@
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13666787566738295" k="206214.74661105775" class1="0" class2="1"/>
-<Bond length="0.135578394121318" k="235028.7987340298" class1="1" class2="2"/>
-<Bond length="0.135578394121318" k="235028.7987340298" class1="1" class2="3"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="0" class2="1"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="1" class2="2"/>
+<Bond length="0.13594155463667298" k="225424.11469303913" class1="1" class2="3"/>
 <Bond length="0.14770475272616868" k="202636.90124838825" class1="1" class2="4"/>
 <Bond length="0.13961052875885102" k="347096.3654153404" class1="4" class2="5"/>
 <Bond length="0.1442192930696654" k="204687.21146882328" class1="4" class2="20"/>
@@ -168,219 +168,219 @@
 <HarmonicAngleForce>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="0" class2="1" class3="2"/>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="0" class2="1" class3="3"/>
-<Angle k="899.3585368640406" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
-<Angle k="596.5783996614795" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
-<Angle k="659.8801083115934" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
 <Angle k="789.3364060820932" angle="1.8470606834084646" class1="2" class2="1" class3="3"/>
+<Angle k="899.3585368640406" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
 <Angle k="899.3585368640406" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
 <Angle k="899.3585368640406" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
+<Angle k="596.5783996614795" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
+<Angle k="659.8801083115934" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
+<Angle k="521.025901967959" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
 <Angle k="607.8024679594919" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
 <Angle k="248.41301966022203" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
-<Angle k="672.8043009719439" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
-<Angle k="720.2813544945968" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
-<Angle k="521.025901967959" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
+<Angle k="252.09238388693245" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
 <Angle k="436.40842761557036" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
 <Angle k="554.0354749576979" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
-<Angle k="252.09238388693245" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
-<Angle k="1351.3545002900366" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
 <Angle k="514.1711048205738" angle="2.0126223566140804" class1="7" class2="6" class3="8"/>
+<Angle k="1351.3545002900366" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
 <Angle k="575.0175235407985" angle="2.013820749887496" class1="8" class2="9" class3="10"/>
 <Angle k="683.378020176922" angle="2.130524412137124" class1="8" class2="9" class3="20"/>
+<Angle k="716.5653468085275" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
 <Angle k="521.341642400924" angle="2.0882702117790397" class1="9" class2="10" class3="11"/>
 <Angle k="600.2256823226334" angle="2.075806905333667" class1="9" class2="10" class3="21"/>
-<Angle k="1116.5669365177487" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
-<Angle k="716.5653468085275" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
+<Angle k="593.550127606366" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
 <Angle k="1054.342543578456" angle="1.9408289971728419" class1="10" class2="11" class3="12"/>
 <Angle k="359.01398101206325" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
 <Angle k="359.01398101206325" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
-<Angle k="688.132896774631" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
-<Angle k="955.3354720930909" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
-<Angle k="593.550127606366" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
+<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
+<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
+<Angle k="340.43451985742695" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
 <Angle k="755.8333070341093" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
 <Angle k="422.53260308902185" angle="1.9290790266726685" class1="11" class2="12" class3="25"/>
 <Angle k="422.53260308902185" angle="1.9290790266726685" class1="11" class2="12" class3="26"/>
-<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
-<Angle k="452.38930228803645" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
+<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
+<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
+<Angle k="308.2771278768513" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
 <Angle k="1058.9233469388728" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
 <Angle k="469.49389457008635" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
 <Angle k="469.49389457008635" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
-<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
-<Angle k="513.2548385275447" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
-<Angle k="683.8532127510415" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
-<Angle k="653.9512111145623" angle="2.1049921908657305" class1="13" class2="14" class3="21"/>
 <Angle k="485.83278011238633" angle="1.8934542661534206" class1="14" class2="13" class3="27"/>
 <Angle k="485.83278011238633" angle="1.8934542661534206" class1="14" class2="13" class3="28"/>
+<Angle k="354.75833684494916" angle="1.8733192331827726" class1="27" class2="13" class3="28"/>
+<Angle k="683.8532127510415" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
+<Angle k="653.9512111145623" angle="2.1049921908657305" class1="13" class2="14" class3="21"/>
+<Angle k="637.1730113108624" angle="2.1139000267281434" class1="15" class2="14" class3="21"/>
 <Angle k="1038.0344508726746" angle="1.9473052141515759" class1="14" class2="15" class3="16"/>
 <Angle k="462.6560372351371" angle="1.8928233604685727" class1="14" class2="15" class3="29"/>
 <Angle k="462.6560372351371" angle="1.8928233604685727" class1="14" class2="15" class3="30"/>
-<Angle k="724.0638672794921" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
-<Angle k="637.1730113108624" angle="2.1139000267281434" class1="15" class2="14" class3="21"/>
+<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
+<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
+<Angle k="367.6928799885423" angle="1.870916290698717" class1="29" class2="15" class3="30"/>
 <Angle k="835.7646154944775" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
 <Angle k="515.6437119630667" angle="1.9073030765505146" class1="15" class2="16" class3="31"/>
 <Angle k="515.6437119630667" angle="1.9073030765505146" class1="15" class2="16" class3="32"/>
-<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
-<Angle k="471.9542212107978" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
+<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
+<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
+<Angle k="298.9762404834261" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
 <Angle k="1076.1529378317775" angle="1.9368504917581069" class1="16" class2="17" class3="18"/>
 <Angle k="437.7829056469467" angle="1.922073455348455" class1="16" class2="17" class3="33"/>
 <Angle k="437.7829056469467" angle="1.922073455348455" class1="16" class2="17" class3="34"/>
-<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
-<Angle k="435.23706367478707" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
-<Angle k="633.4042134855656" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
-<Angle k="566.8603045200415" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
 <Angle k="441.0116676759102" angle="1.9124271197621583" class1="18" class2="17" class3="33"/>
 <Angle k="441.0116676759102" angle="1.9124271197621583" class1="18" class2="17" class3="34"/>
+<Angle k="302.72200221590714" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="633.4042134855656" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
+<Angle k="566.8603045200415" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
+<Angle k="690.2261815337827" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
 <Angle k="692.4324262826096" angle="2.141228147888421" class1="18" class2="19" class3="20"/>
 <Angle k="267.2688732204102" angle="2.067499239359301" class1="18" class2="19" class3="35"/>
-<Angle k="690.2261815337827" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
 <Angle k="274.32316551133624" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
-<Angle k="340.43451985742695" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
-<Angle k="308.2771278768513" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
-<Angle k="354.75833684494916" angle="1.8733192331827726" class1="27" class2="13" class3="28"/>
-<Angle k="367.6928799885423" angle="1.870916290698717" class1="29" class2="15" class3="30"/>
-<Angle k="298.9762404834261" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
-<Angle k="302.72200221590714" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="672.8043009719439" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
+<Angle k="720.2813544945968" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
+<Angle k="1116.5669365177487" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
+<Angle k="688.132896774631" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
+<Angle k="955.3354720930909" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
+<Angle k="724.0638672794921" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
 </HarmonicAngleForce>
 <PeriodicTorsionForce ordering="smirnoff">
-<Proper k1="8.844753176022e-07" k2="-1.820903850195" k3="2.475278502164" k4="1.321757556511e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="1.143371173344e-06" k2="8.456581188434e-07" k3="1.208155188113" k4="1.312432122949e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="8.844753176022e-07" k2="-1.820903850195" k3="2.475278502164" k4="1.321757556511e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="1.143371173344e-06" k2="8.456581188434e-07" k3="1.208155188113" k4="1.312432122949e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="8.844753176022e-07" k2="-1.820903850195" k3="2.475278502164" k4="1.321757556511e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="1.143371173344e-06" k2="8.456581188434e-07" k3="1.208155188113" k4="1.312432122949e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+<Proper k1="9.92718097755e-07" k2="-1.820903537066" k3="2.475281715041" k4="1.711318749904e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="8.966529940237e-07" k2="6.826143498748e-07" k3="1.238254009321" k4="1.855137925669e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="9.92718097755e-07" k2="-1.820903537066" k3="2.475281715041" k4="1.711318749904e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="8.966529940237e-07" k2="6.826143498748e-07" k3="1.238254009321" k4="1.855137925669e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="9.92718097755e-07" k2="-1.820903537066" k3="2.475281715041" k4="1.711318749904e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="8.966529940237e-07" k2="6.826143498748e-07" k3="1.238254009321" k4="1.855137925669e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
 </PeriodicTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
 <Atom charge="-0.264836" epsilon="0.24454981151424124" sigma="0.2992019647933705" type="QUBE_0"/>
@@ -418,7 +418,7 @@
 <Atom charge="0.100277" epsilon="0.0834669438818803" sigma="0.24089722551435258" type="QUBE_32"/>
 <Atom charge="0.106005" epsilon="0.08392405597588261" sigma="0.24188256083188234" type="QUBE_33"/>
 <Atom charge="0.106005" epsilon="0.08392405597588261" sigma="0.24188256083188234" type="QUBE_34"/>
-<Atom charge="0.12477" epsilon="0.08801330957484484" sigma="0.2506380050397751" type="QUBE_35"/>
+<Atom charge="0.124770" epsilon="0.08801330957484484" sigma="0.2506380050397751" type="QUBE_35"/>
 <Atom charge="-0.059761" epsilon="0" sigma="1" type="v-site1"/>
 <Atom charge="-0.059761" epsilon="0" sigma="1" type="v-site2"/>
 </NonbondedForce>

--- a/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-sites-qforce-ub-rfree.xml
+++ b/force_fields/excited/cam-b3lp-refit-rfree/coumarin-excited-sites-qforce-ub-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1+18.g864d8cb.dirty" Date="2022_08_25"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -120,320 +120,260 @@
 <Bond from="18" to="21"/>
 <Bond from="19" to="20"/>
 <Bond from="19" to="35"/>
-<Bond from="0" to="2"/>
-<Bond from="0" to="3"/>
-<Bond from="0" to="4"/>
-<Bond from="1" to="5"/>
-<Bond from="1" to="20"/>
-<Bond from="2" to="3"/>
-<Bond from="2" to="4"/>
-<Bond from="3" to="4"/>
-<Bond from="4" to="6"/>
-<Bond from="4" to="22"/>
-<Bond from="4" to="9"/>
-<Bond from="4" to="19"/>
-<Bond from="5" to="20"/>
-<Bond from="5" to="7"/>
-<Bond from="5" to="8"/>
-<Bond from="6" to="22"/>
-<Bond from="6" to="9"/>
-<Bond from="7" to="8"/>
-<Bond from="8" to="10"/>
-<Bond from="8" to="20"/>
-<Bond from="9" to="11"/>
-<Bond from="9" to="21"/>
-<Bond from="9" to="19"/>
-<Bond from="10" to="20"/>
-<Bond from="10" to="12"/>
-<Bond from="10" to="23"/>
-<Bond from="10" to="24"/>
-<Bond from="10" to="14"/>
-<Bond from="10" to="18"/>
-<Bond from="11" to="21"/>
-<Bond from="11" to="13"/>
-<Bond from="11" to="25"/>
-<Bond from="11" to="26"/>
-<Bond from="12" to="23"/>
-<Bond from="12" to="24"/>
-<Bond from="12" to="14"/>
-<Bond from="12" to="27"/>
-<Bond from="12" to="28"/>
-<Bond from="13" to="25"/>
-<Bond from="13" to="26"/>
-<Bond from="13" to="15"/>
-<Bond from="13" to="21"/>
-<Bond from="14" to="27"/>
-<Bond from="14" to="28"/>
-<Bond from="14" to="16"/>
-<Bond from="14" to="29"/>
-<Bond from="14" to="30"/>
-<Bond from="14" to="18"/>
-<Bond from="15" to="21"/>
-<Bond from="15" to="17"/>
-<Bond from="15" to="31"/>
-<Bond from="15" to="32"/>
-<Bond from="16" to="29"/>
-<Bond from="16" to="30"/>
-<Bond from="16" to="18"/>
-<Bond from="16" to="33"/>
-<Bond from="16" to="34"/>
-<Bond from="17" to="31"/>
-<Bond from="17" to="32"/>
-<Bond from="17" to="19"/>
-<Bond from="17" to="21"/>
-<Bond from="18" to="33"/>
-<Bond from="18" to="34"/>
-<Bond from="18" to="20"/>
-<Bond from="18" to="35"/>
-<Bond from="19" to="21"/>
-<Bond from="20" to="35"/>
-<Bond from="23" to="24"/>
-<Bond from="25" to="26"/>
-<Bond from="27" to="28"/>
-<Bond from="29" to="30"/>
-<Bond from="31" to="32"/>
-<Bond from="33" to="34"/>
 <VirtualSite p1="-0.0326" p2="-0.0534" p3="0.0626" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="36"/>
 <VirtualSite p1="-0.0326" p2="-0.0534" p3="-0.0626" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="37"/>
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13594155463667298" k="218364.33426195718" class1="0" class2="1"/>
-<Bond length="0.13594155463667298" k="218364.33426195718" class1="1" class2="2"/>
-<Bond length="0.13594155463667298" k="218364.33426195718" class1="1" class2="3"/>
-<Bond length="0.14770475272616868" k="197325.8598022209" class1="1" class2="4"/>
-<Bond length="0.13961052875885102" k="347885.49521745136" class1="4" class2="5"/>
-<Bond length="0.1442192930696654" k="188162.73618809003" class1="4" class2="20"/>
-<Bond length="0.14223091098938934" k="283502.51679768274" class1="5" class2="6"/>
-<Bond length="0.10822001583405008" k="334985.2424663566" class1="5" class2="22"/>
-<Bond length="0.12173305755747404" k="631763.2447635473" class1="6" class2="7"/>
-<Bond length="0.14175110272148425" k="110068.86835017371" class1="6" class2="8"/>
-<Bond length="0.13571416599367517" k="266442.2924398931" class1="8" class2="9"/>
-<Bond length="0.1382083808080489" k="317272.5586967854" class1="9" class2="10"/>
-<Bond length="0.142453038842533" k="192803.3948647591" class1="9" class2="20"/>
-<Bond length="0.15060063293211423" k="199009.6015532343" class1="10" class2="11"/>
-<Bond length="0.14258713560769964" k="214800.21586417197" class1="10" class2="21"/>
-<Bond length="0.15227572432554826" k="189644.57824711432" class1="11" class2="12"/>
-<Bond length="0.10958672840190148" k="296872.99898624903" class1="11" class2="23"/>
-<Bond length="0.10958672840190148" k="296872.99898624903" class1="11" class2="24"/>
-<Bond length="0.1519270774055388" k="188003.7058086625" class1="12" class2="13"/>
-<Bond length="0.10952500777673012" k="300676.57677884697" class1="12" class2="25"/>
-<Bond length="0.10952500777673012" k="300676.57677884697" class1="12" class2="26"/>
-<Bond length="0.14565680593432032" k="190978.2454754645" class1="13" class2="14"/>
-<Bond length="0.10983719228431021" k="290679.80755314796" class1="13" class2="27"/>
-<Bond length="0.10983719228431021" k="290679.80755314796" class1="13" class2="28"/>
-<Bond length="0.14565680593432032" k="190978.2454754645" class1="14" class2="15"/>
-<Bond length="0.1369783820752729" k="293769.68165266595" class1="14" class2="21"/>
-<Bond length="0.15193935490482638" k="188942.77603944583" class1="15" class2="16"/>
-<Bond length="0.10983719228431021" k="290679.80755314796" class1="15" class2="29"/>
-<Bond length="0.10983719228431021" k="290679.80755314796" class1="15" class2="30"/>
-<Bond length="0.1523142800205355" k="188971.40801485837" class1="16" class2="17"/>
-<Bond length="0.10952502935011754" k="300795.18322035467" class1="16" class2="31"/>
-<Bond length="0.10952502935011754" k="300795.18322035467" class1="16" class2="32"/>
-<Bond length="0.15063936367015732" k="203614.89589978306" class1="17" class2="18"/>
-<Bond length="0.10969834880306709" k="293255.64977765596" class1="17" class2="33"/>
-<Bond length="0.10969834880306709" k="293255.64977765596" class1="17" class2="34"/>
-<Bond length="0.1376230871323796" k="329065.70750355424" class1="18" class2="19"/>
-<Bond length="0.14311745649268223" k="213246.62640824832" class1="18" class2="21"/>
-<Bond length="0.14157012681086414" k="238175.96337031838" class1="19" class2="20"/>
-<Bond length="0.10836619841427811" k="333700.88550085237" class1="19" class2="35"/>
-<Bond length="0.21689078360673025" k="64090.928920937666" class1="0" class2="2"/>
-<Bond length="0.21689078360673025" k="64090.928920937666" class1="0" class2="3"/>
-<Bond length="0.2364864474629915" k="41689.77615181736" class1="0" class2="4"/>
-<Bond length="0.25017868954369815" k="11122.340783140044" class1="1" class2="5"/>
-<Bond length="0.2534860324725394" k="61525.70196041935" class1="1" class2="20"/>
-<Bond length="0.21689078360673025" k="64090.928920937666" class1="2" class2="3"/>
-<Bond length="0.2364864474629915" k="41689.77615181736" class1="2" class2="4"/>
-<Bond length="0.2364864474629915" k="41689.77615181736" class1="3" class2="4"/>
-<Bond length="0.24782238837806544" k="27268.15979350136" class1="4" class2="6"/>
-<Bond length="0.2165030574017915" k="12336.20543591911" class1="4" class2="22"/>
-<Bond length="0.2455736310625806" k="46737.86552503985" class1="4" class2="9"/>
-<Bond length="0.2537722246826899" k="33387.44381297549" class1="4" class2="19"/>
-<Bond length="0.24378442341267956" k="49730.87512326398" class1="5" class2="20"/>
-<Bond length="0.23745488882021154" k="61674.850527951196" class1="5" class2="7"/>
-<Bond length="0.2416757937731322" k="44226.38309720752" class1="5" class2="8"/>
-<Bond length="0.21275502134276836" k="18507.18227312681" class1="6" class2="22"/>
-<Bond length="0.2423514965995231" k="47263.949798427246" class1="6" class2="9"/>
-<Bond length="0.2228657733109233" k="79108.09362920695" class1="7" class2="8"/>
-<Bond length="0.23151894390905997" k="62808.9035091798" class1="8" class2="10"/>
-<Bond length="0.24339480040217093" k="30458.85970731149" class1="8" class2="20"/>
-<Bond length="0.24975022931680144" k="19986.911487342946" class1="9" class2="11"/>
-<Bond length="0.24187092582637876" k="39843.233301278306" class1="9" class2="21"/>
-<Bond length="0.24201627686067356" k="53178.843376940735" class1="9" class2="19"/>
-<Bond length="0.24612569405012136" k="43761.680612024335" class1="10" class2="20"/>
-<Bond length="0.24991111909979238" k="22545.21974343678" class1="10" class2="12"/>
-<Bond length="0.21364058799943095" k="19171.882299981393" class1="10" class2="23"/>
-<Bond length="0.21364058799943095" k="19171.882299981393" class1="10" class2="24"/>
-<Bond length="0.2420248299327458" k="48862.16639655606" class1="10" class2="14"/>
-<Bond length="0.24712865951164575" k="50771.67473870957" class1="10" class2="18"/>
-<Bond length="0.25572586399439895" k="18304.550299811206" class1="11" class2="21"/>
-<Bond length="0.24901456266768196" k="33263.03908213184" class1="11" class2="13"/>
-<Bond length="0.2165189488422092" k="10980.252001208415" class1="11" class2="25"/>
-<Bond length="0.2165189488422092" k="10980.252001208415" class1="11" class2="26"/>
-<Bond length="0.21661802925246812" k="11549.460375339895" class1="12" class2="23"/>
-<Bond length="0.21661802925246812" k="11549.460375339895" class1="12" class2="24"/>
-<Bond length="0.2454186379331869" k="34999.26413840515" class1="12" class2="14"/>
-<Bond length="0.21661401961453586" k="11907.68982314365" class1="12" class2="27"/>
-<Bond length="0.21661401961453586" k="11907.68982314365" class1="12" class2="28"/>
-<Bond length="0.21452792982373092" k="13084.018837224647" class1="13" class2="25"/>
-<Bond length="0.21452792982373092" k="13084.018837224647" class1="13" class2="26"/>
-<Bond length="0.24778380868952166" k="5644.767125564244" class1="13" class2="15"/>
-<Bond length="0.24586309792299157" k="25417.688925560487" class1="13" class2="21"/>
-<Bond length="0.20836612491682935" k="23571.027102586493" class1="14" class2="27"/>
-<Bond length="0.20836612491682935" k="23571.027102586493" class1="14" class2="28"/>
-<Bond length="0.24612101687514346" k="33438.75667296287" class1="14" class2="16"/>
-<Bond length="0.20836612491682935" k="23571.027102586493" class1="14" class2="29"/>
-<Bond length="0.20836612491682935" k="23571.027102586493" class1="14" class2="30"/>
-<Bond length="0.24297788191575906" k="46749.20508164152" class1="14" class2="18"/>
-<Bond length="0.24586309792299157" k="25417.688925560487" class1="15" class2="21"/>
-<Bond length="0.24828371990244094" k="32218.101329517587" class1="15" class2="17"/>
-<Bond length="0.21464121187011923" k="13346.09607934216" class1="15" class2="31"/>
-<Bond length="0.21464121187011923" k="13346.09607934216" class1="15" class2="32"/>
-<Bond length="0.21644638235158423" k="11130.436276845376" class1="16" class2="29"/>
-<Bond length="0.21644638235158423" k="11130.436276845376" class1="16" class2="30"/>
-<Bond length="0.2496339349142613" k="22852.461864410612" class1="16" class2="18"/>
-<Bond length="0.21617620291307876" k="12280.416125217776" class1="16" class2="33"/>
-<Bond length="0.21617620291307876" k="12280.416125217776" class1="16" class2="34"/>
-<Bond length="0.21671848266256852" k="10861.001118017533" class1="17" class2="31"/>
-<Bond length="0.21671848266256852" k="10861.001118017533" class1="17" class2="32"/>
-<Bond length="0.25035622871790025" k="17928.306438768683" class1="17" class2="19"/>
-<Bond length="0.25484547528105317" k="17286.42277641112" class1="17" class2="21"/>
-<Bond length="0.21400564848019982" k="17944.72121529175" class1="18" class2="33"/>
-<Bond length="0.21400564848019982" k="17944.72121529175" class1="18" class2="34"/>
-<Bond length="0.2449980098005106" k="62447.500660831145" class1="18" class2="20"/>
-<Bond length="0.21188905925070795" k="10051.090670559823" class1="18" class2="35"/>
-<Bond length="0.24211627925518933" k="46968.82183164349" class1="19" class2="21"/>
-<Bond length="0.21585169241853103" k="7602.413381693731" class1="20" class2="35"/>
-<Bond length="0.17455161176521647" k="14193.910253734024" class1="23" class2="24"/>
-<Bond length="0.17659145737057533" k="13408.86920865169" class1="25" class2="26"/>
-<Bond length="0.1768878357199081" k="13375.00262962718" class1="27" class2="28"/>
-<Bond length="0.1768878357199081" k="13375.00262962718" class1="29" class2="30"/>
-<Bond length="0.17669982064045128" k="13250.417677211197" class1="31" class2="32"/>
-<Bond length="0.17561999811379547" k="14138.072355052609" class1="33" class2="34"/>
+<Bond length="0.13594155463667298" k="218364.33426196885" class1="0" class2="1"/>
+<Bond length="0.13594155463667298" k="218364.33426196885" class1="1" class2="2"/>
+<Bond length="0.13594155463667298" k="218364.33426196885" class1="1" class2="3"/>
+<Bond length="0.14770475272616868" k="197325.8598022312" class1="1" class2="4"/>
+<Bond length="0.13961052875885102" k="347885.4952174525" class1="4" class2="5"/>
+<Bond length="0.14421929306966538" k="188162.73618808694" class1="4" class2="20"/>
+<Bond length="0.1422309109893893" k="283502.5167976814" class1="5" class2="6"/>
+<Bond length="0.10822001583405005" k="334985.2424663604" class1="5" class2="22"/>
+<Bond length="0.12173305755747404" k="631763.2447635459" class1="6" class2="7"/>
+<Bond length="0.14175110272148425" k="110068.86835017553" class1="6" class2="8"/>
+<Bond length="0.1357141659936751" k="266442.2924398916" class1="8" class2="9"/>
+<Bond length="0.13820838080804893" k="317272.55869678326" class1="9" class2="10"/>
+<Bond length="0.14245303884253296" k="192803.39486476703" class1="9" class2="20"/>
+<Bond length="0.15060063293211423" k="199009.60155324117" class1="10" class2="11"/>
+<Bond length="0.14258713560769973" k="214800.21586416182" class1="10" class2="21"/>
+<Bond length="0.1522757243255483" k="189644.57824711065" class1="11" class2="12"/>
+<Bond length="0.10958672840190148" k="296872.99898625445" class1="11" class2="23"/>
+<Bond length="0.10958672840190148" k="296872.99898625445" class1="11" class2="24"/>
+<Bond length="0.1519270774055388" k="188003.70580867308" class1="12" class2="13"/>
+<Bond length="0.10952500777673013" k="300676.5767788474" class1="12" class2="25"/>
+<Bond length="0.10952500777673013" k="300676.5767788474" class1="12" class2="26"/>
+<Bond length="0.14565680593432032" k="190978.24547547233" class1="13" class2="14"/>
+<Bond length="0.10983719228431021" k="290679.80755314406" class1="13" class2="27"/>
+<Bond length="0.10983719228431021" k="290679.80755314406" class1="13" class2="28"/>
+<Bond length="0.14565680593432032" k="190978.24547547233" class1="14" class2="15"/>
+<Bond length="0.13697838207527296" k="293769.68165266514" class1="14" class2="21"/>
+<Bond length="0.15193935490482638" k="188942.77603944435" class1="15" class2="16"/>
+<Bond length="0.10983719228431021" k="290679.80755314406" class1="15" class2="29"/>
+<Bond length="0.10983719228431021" k="290679.80755314406" class1="15" class2="30"/>
+<Bond length="0.1523142800205355" k="188971.4080148623" class1="16" class2="17"/>
+<Bond length="0.10952502935011754" k="300795.18322035176" class1="16" class2="31"/>
+<Bond length="0.10952502935011754" k="300795.18322035176" class1="16" class2="32"/>
+<Bond length="0.1506393636701573" k="203614.89589977116" class1="17" class2="18"/>
+<Bond length="0.10969834880306709" k="293255.64977765223" class1="17" class2="33"/>
+<Bond length="0.10969834880306709" k="293255.64977765223" class1="17" class2="34"/>
+<Bond length="0.1376230871323796" k="329065.70750354795" class1="18" class2="19"/>
+<Bond length="0.14311745649268223" k="213246.6264082468" class1="18" class2="21"/>
+<Bond length="0.14157012681086414" k="238175.9633703211" class1="19" class2="20"/>
+<Bond length="0.10836619841427811" k="333700.88550084975" class1="19" class2="35"/>
 </HarmonicBondForce>
 <HarmonicAngleForce>
-<Angle k="614.2636834764451" angle="1.8470606834084642" class1="0" class2="1" class3="2"/>
-<Angle k="614.2636834764451" angle="1.8470606834084642" class1="0" class2="1" class3="3"/>
-<Angle k="497.1053682429308" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
-<Angle k="458.7050549723287" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
-<Angle k="163.36584359861067" angle="2.1035640083738585" class1="1" class2="4" class3="20"/>
-<Angle k="614.2636834764451" angle="1.8470606834084642" class1="2" class2="1" class3="3"/>
-<Angle k="497.1053682429308" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
-<Angle k="497.1053682429308" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
-<Angle k="455.67815232673564" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
-<Angle k="238.42916730061603" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
-<Angle k="647.1232934745271" angle="2.057401449027927" class1="4" class2="20" class3="9"/>
-<Angle k="658.8795717881886" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
-<Angle k="218.1924970791139" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
-<Angle k="58.2811279038529" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
-<Angle k="194.75227121139295" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
-<Angle k="474.11244658987016" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
-<Angle k="754.3587269079211" angle="2.0126223566140804" class1="7" class2="6" class3="8"/>
-<Angle k="535.4518878348202" angle="2.013820749887496" class1="8" class2="9" class3="10"/>
-<Angle k="300.98970133308364" angle="2.130524412137124" class1="8" class2="9" class3="20"/>
-<Angle k="298.69652379000377" angle="2.0882702117790397" class1="9" class2="10" class3="11"/>
-<Angle k="322.56545519039156" angle="2.075806905333667" class1="9" class2="10" class3="21"/>
-<Angle k="164.178400585315" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
-<Angle k="191.3950034660413" angle="2.13882661763376" class1="10" class2="9" class3="20"/>
-<Angle k="412.2328706798046" angle="1.9408289971728419" class1="10" class2="11" class3="12"/>
-<Angle k="294.0484379775051" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
-<Angle k="294.0484379775051" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
-<Angle k="476.8577297283859" angle="2.0929323362089973" class1="10" class2="21" class3="14"/>
-<Angle k="189.59163181832383" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
-<Angle k="434.3655285725271" angle="2.1190494113986427" class1="11" class2="10" class3="21"/>
-<Angle k="597.0145182672675" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
-<Angle k="353.7464345623701" angle="1.9290790266726685" class1="11" class2="12" class3="25"/>
-<Angle k="353.7464345623701" angle="1.9290790266726685" class1="11" class2="12" class3="26"/>
-<Angle k="341.57727646293534" angle="1.929808602900578" class1="12" class2="11" class3="23"/>
-<Angle k="341.57727646293534" angle="1.929808602900578" class1="12" class2="11" class3="24"/>
-<Angle k="541.1985527045957" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
-<Angle k="331.9244955549747" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
-<Angle k="331.9244955549747" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
-<Angle k="339.7358397789421" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
-<Angle k="339.7358397789421" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
-<Angle k="556.4926097759561" angle="2.0341520950032144" class1="13" class2="14" class3="15"/>
-<Angle k="334.9302198644204" angle="2.109446108796937" class1="13" class2="14" class3="21"/>
-<Angle k="366.50301957436886" angle="1.8931388133109963" class1="14" class2="13" class3="27"/>
-<Angle k="366.50301957436886" angle="1.8931388133109963" class1="14" class2="13" class3="28"/>
-<Angle k="544.469157998077" angle="1.9473052141515759" class1="14" class2="15" class3="16"/>
-<Angle k="366.50301957436886" angle="1.8931388133109963" class1="14" class2="15" class3="29"/>
-<Angle k="366.50301957436886" angle="1.8931388133109963" class1="14" class2="15" class3="30"/>
-<Angle k="586.8322789005881" angle="2.099957568724772" class1="14" class2="21" class3="18"/>
-<Angle k="334.9302198644204" angle="2.109446108796937" class1="15" class2="14" class3="21"/>
-<Angle k="591.6113469839247" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
-<Angle k="344.19340503445727" angle="1.9073030765505146" class1="15" class2="16" class3="31"/>
-<Angle k="344.19340503445727" angle="1.9073030765505146" class1="15" class2="16" class3="32"/>
-<Angle k="340.7776751329713" angle="1.9289190615492369" class1="16" class2="15" class3="29"/>
-<Angle k="340.7776751329713" angle="1.9289190615492369" class1="16" class2="15" class3="30"/>
-<Angle k="418.9486380337046" angle="1.9368504917581066" class1="16" class2="17" class3="18"/>
-<Angle k="345.66365076565427" angle="1.922073455348455" class1="16" class2="17" class3="33"/>
-<Angle k="345.66365076565427" angle="1.922073455348455" class1="16" class2="17" class3="34"/>
-<Angle k="356.16847070242" angle="1.9313757859816711" class1="17" class2="16" class3="31"/>
-<Angle k="356.16847070242" angle="1.9313757859816711" class1="17" class2="16" class3="32"/>
-<Angle k="509.4295877149267" angle="2.103174723548533" class1="17" class2="18" class3="19"/>
-<Angle k="380.0889683081698" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
-<Angle k="293.28292094403577" angle="1.9124271197621583" class1="18" class2="17" class3="33"/>
-<Angle k="293.28292094403577" angle="1.9124271197621583" class1="18" class2="17" class3="34"/>
-<Angle k="363.8650496267183" angle="2.141228147888421" class1="18" class2="19" class3="20"/>
-<Angle k="264.7711051279627" angle="2.067499239359301" class1="18" class2="19" class3="35"/>
-<Angle k="252.50869426245953" angle="2.079837707785646" class1="19" class2="18" class3="21"/>
-<Angle k="265.77012781184976" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
-<Angle k="254.07433427840567" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
-<Angle k="268.6657113566651" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
-<Angle k="254.9738466322176" angle="1.8721177619407448" class1="27" class2="13" class3="28"/>
-<Angle k="254.9738466322176" angle="1.8721177619407448" class1="29" class2="15" class3="30"/>
-<Angle k="266.4963972198804" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
-<Angle k="265.25532837302046" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
+<Angle k="614.2636834765092" angle="1.8470606834084646" class1="0" class2="1" class3="2"/>
+<Angle k="614.2636834765092" angle="1.8470606834084646" class1="0" class2="1" class3="3"/>
+<Angle k="497.10536824270366" angle="1.9705425130225465" class1="0" class2="1" class3="4"/>
+<Angle k="458.70505497239384" angle="2.1129870635326364" class1="1" class2="4" class3="5"/>
+<Angle k="163.36584359868783" angle="2.103564008373859" class1="1" class2="4" class3="20"/>
+<Angle k="614.2636834765092" angle="1.8470606834084646" class1="2" class2="1" class3="3"/>
+<Angle k="497.10536824270366" angle="1.9705425130225465" class1="2" class2="1" class3="4"/>
+<Angle k="497.10536824270366" angle="1.9705425130225465" class1="3" class2="1" class3="4"/>
+<Angle k="455.6781523267416" angle="2.1487222924751657" class1="4" class2="5" class3="6"/>
+<Angle k="238.42916730057937" angle="2.116017070767214" class1="4" class2="5" class3="22"/>
+<Angle k="647.1232934745541" angle="2.0574014490279273" class1="4" class2="20" class3="9"/>
+<Angle k="658.8795717881617" angle="2.1857767394240954" class1="4" class2="20" class3="19"/>
+<Angle k="2.2208677468132964e-27" angle="2.066119791089644" class1="5" class2="4" class3="20"/>
+<Angle k="218.19249707917658" angle="2.234640135045827" class1="5" class2="6" class3="7"/>
+<Angle k="58.28112790371959" angle="2.03586651214064" class1="5" class2="6" class3="8"/>
+<Angle k="194.75227121141637" angle="2.018392034217967" class1="6" class2="5" class3="22"/>
+<Angle k="474.11244659001386" angle="2.124214681136769" class1="6" class2="8" class3="9"/>
+<Angle k="754.3587269078027" angle="2.01262235661408" class1="7" class2="6" class3="8"/>
+<Angle k="535.4518878345926" angle="2.0138207498874956" class1="8" class2="9" class3="10"/>
+<Angle k="300.98970133301515" angle="2.1305244121371243" class1="8" class2="9" class3="20"/>
+<Angle k="298.696523790353" angle="2.08827021177904" class1="9" class2="10" class3="11"/>
+<Angle k="322.56545519035143" angle="2.0758069053336667" class1="9" class2="10" class3="21"/>
+<Angle k="164.17840058538206" angle="2.039965258400442" class1="9" class2="20" class3="19"/>
+<Angle k="191.39500346604177" angle="2.1388266176337605" class1="10" class2="9" class3="20"/>
+<Angle k="412.2328706793746" angle="1.9408289971728416" class1="10" class2="11" class3="12"/>
+<Angle k="294.04843797735236" angle="1.909025249861946" class1="10" class2="11" class3="23"/>
+<Angle k="294.04843797735236" angle="1.909025249861946" class1="10" class2="11" class3="24"/>
+<Angle k="476.8577297283222" angle="2.092932336208997" class1="10" class2="21" class3="14"/>
+<Angle k="189.5916318182167" angle="2.090217654764545" class1="10" class2="21" class3="18"/>
+<Angle k="434.36552857280225" angle="2.119049411398643" class1="11" class2="10" class3="21"/>
+<Angle k="597.0145182674585" angle="1.9178706856431105" class1="11" class2="12" class3="13"/>
+<Angle k="353.74643456253364" angle="1.9290790266726683" class1="11" class2="12" class3="25"/>
+<Angle k="353.74643456253364" angle="1.9290790266726683" class1="11" class2="12" class3="26"/>
+<Angle k="341.57727646314" angle="1.9298086029005783" class1="12" class2="11" class3="23"/>
+<Angle k="341.57727646314" angle="1.9298086029005783" class1="12" class2="11" class3="24"/>
+<Angle k="541.1985527048296" angle="1.9390529016524454" class1="12" class2="13" class3="14"/>
+<Angle k="331.9244955548339" angle="1.93139238827617" class1="12" class2="13" class3="27"/>
+<Angle k="331.9244955548339" angle="1.93139238827617" class1="12" class2="13" class3="28"/>
+<Angle k="339.7358397788832" angle="1.9059029990247227" class1="13" class2="12" class3="25"/>
+<Angle k="339.7358397788832" angle="1.9059029990247227" class1="13" class2="12" class3="26"/>
+<Angle k="556.4926097759752" angle="2.034152095003215" class1="13" class2="14" class3="15"/>
+<Angle k="334.9302198644082" angle="2.109446108796937" class1="13" class2="14" class3="21"/>
+<Angle k="366.503019574448" angle="1.8931388133109963" class1="14" class2="13" class3="27"/>
+<Angle k="366.503019574448" angle="1.8931388133109963" class1="14" class2="13" class3="28"/>
+<Angle k="544.4691579981877" angle="1.9473052141515765" class1="14" class2="15" class3="16"/>
+<Angle k="366.503019574448" angle="1.8931388133109963" class1="14" class2="15" class3="29"/>
+<Angle k="366.503019574448" angle="1.8931388133109963" class1="14" class2="15" class3="30"/>
+<Angle k="586.832278900658" angle="2.0999575687247725" class1="14" class2="21" class3="18"/>
+<Angle k="334.9302198644082" angle="2.109446108796937" class1="15" class2="14" class3="21"/>
+<Angle k="591.6113469838108" angle="1.90905803914857" class1="15" class2="16" class3="17"/>
+<Angle k="344.1934050344511" angle="1.9073030765505143" class1="15" class2="16" class3="31"/>
+<Angle k="344.1934050344511" angle="1.9073030765505143" class1="15" class2="16" class3="32"/>
+<Angle k="340.77767513294475" angle="1.928919061549237" class1="16" class2="15" class3="29"/>
+<Angle k="340.77767513294475" angle="1.928919061549237" class1="16" class2="15" class3="30"/>
+<Angle k="418.94863803389603" angle="1.9368504917581069" class1="16" class2="17" class3="18"/>
+<Angle k="345.66365076563375" angle="1.9220734553484546" class1="16" class2="17" class3="33"/>
+<Angle k="345.66365076563375" angle="1.9220734553484546" class1="16" class2="17" class3="34"/>
+<Angle k="356.1684707023652" angle="1.9313757859816714" class1="17" class2="16" class3="31"/>
+<Angle k="356.1684707023652" angle="1.9313757859816714" class1="17" class2="16" class3="32"/>
+<Angle k="509.42958771487383" angle="2.103174723548534" class1="17" class2="18" class3="19"/>
+<Angle k="380.08896830805986" angle="2.1000890383881052" class1="17" class2="18" class3="21"/>
+<Angle k="293.28292094410546" angle="1.912427119762158" class1="18" class2="17" class3="33"/>
+<Angle k="293.28292094410546" angle="1.912427119762158" class1="18" class2="17" class3="34"/>
+<Angle k="363.8650496266965" angle="2.1412281478884214" class1="18" class2="19" class3="20"/>
+<Angle k="264.7711051279836" angle="2.0674992393593006" class1="18" class2="19" class3="35"/>
+<Angle k="252.5086942624643" angle="2.0798377077856456" class1="19" class2="18" class3="21"/>
+<Angle k="265.77012781182776" angle="2.074383117131796" class1="20" class2="19" class3="35"/>
+<Angle k="254.0743342784285" angle="1.8426662127618112" class1="23" class2="11" class3="24"/>
+<Angle k="268.6657113566057" angle="1.8752989941798144" class1="25" class2="12" class3="26"/>
+<Angle k="254.97384663220393" angle="1.8721177619407448" class1="27" class2="13" class3="28"/>
+<Angle k="254.97384663220393" angle="1.8721177619407448" class1="29" class2="15" class3="30"/>
+<Angle k="266.49639721988666" angle="1.8769715730525667" class1="31" class2="16" class3="32"/>
+<Angle k="265.2553283730013" angle="1.8561506759586603" class1="33" class2="17" class3="34"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce>
+<UreyBradley k="32045.464460466712" d="0.2168907836067303" class1="0" class2="1" class3="2"/>
+<UreyBradley k="32045.464460466712" d="0.2168907836067303" class1="0" class2="1" class3="3"/>
+<UreyBradley k="20844.888075901737" d="0.2364864474629915" class1="0" class2="1" class3="4"/>
+<UreyBradley k="5561.1703915717" d="0.25017868954369815" class1="1" class2="4" class3="5"/>
+<UreyBradley k="30762.850980210434" d="0.2534860324725394" class1="1" class2="4" class3="20"/>
+<UreyBradley k="32045.464460466712" d="0.2168907836067303" class1="2" class2="1" class3="3"/>
+<UreyBradley k="20844.888075901737" d="0.2364864474629915" class1="2" class2="1" class3="4"/>
+<UreyBradley k="20844.888075901737" d="0.2364864474629915" class1="3" class2="1" class3="4"/>
+<UreyBradley k="13634.079896752357" d="0.2478223883780654" class1="4" class2="5" class3="6"/>
+<UreyBradley k="6168.102717958872" d="0.2165030574017915" class1="4" class2="5" class3="22"/>
+<UreyBradley k="23368.932762523018" d="0.24557363106258057" class1="4" class2="20" class3="9"/>
+<UreyBradley k="16693.72190648552" d="0.25377222468268984" class1="4" class2="20" class3="19"/>
+<UreyBradley k="24865.437561632363" d="0.2437844234126795" class1="5" class2="4" class3="20"/>
+<UreyBradley k="30837.42526397402" d="0.23745488882021154" class1="5" class2="6" class3="7"/>
+<UreyBradley k="22113.191548601426" d="0.24167579377313217" class1="5" class2="6" class3="8"/>
+<UreyBradley k="9253.59113656424" d="0.2127550213427683" class1="6" class2="5" class3="22"/>
+<UreyBradley k="23631.974899214394" d="0.24235149659952304" class1="6" class2="8" class3="9"/>
+<UreyBradley k="39554.046814601286" d="0.2228657733109233" class1="7" class2="6" class3="8"/>
+<UreyBradley k="31404.451754588354" d="0.23151894390905992" class1="8" class2="9" class3="10"/>
+<UreyBradley k="15229.429853654508" d="0.24339480040217087" class1="8" class2="9" class3="20"/>
+<UreyBradley k="9993.455743675631" d="0.24975022931680146" class1="9" class2="10" class3="11"/>
+<UreyBradley k="19921.616650639688" d="0.2418709258263788" class1="9" class2="10" class3="21"/>
+<UreyBradley k="26589.421688470593" d="0.2420162768606735" class1="9" class2="20" class3="19"/>
+<UreyBradley k="21880.840306010057" d="0.24612569405012136" class1="10" class2="9" class3="20"/>
+<UreyBradley k="11272.609871712313" d="0.24991111909979238" class1="10" class2="11" class3="12"/>
+<UreyBradley k="9585.941149986584" d="0.2136405879994309" class1="10" class2="11" class3="23"/>
+<UreyBradley k="9585.941149986584" d="0.2136405879994309" class1="10" class2="11" class3="24"/>
+<UreyBradley k="24431.083198280074" d="0.24202482993274588" class1="10" class2="21" class3="14"/>
+<UreyBradley k="25385.837369354605" d="0.2471286595116458" class1="10" class2="21" class3="18"/>
+<UreyBradley k="9152.275149913927" d="0.255725863994399" class1="11" class2="10" class3="21"/>
+<UreyBradley k="16631.519541078036" d="0.24901456266768196" class1="11" class2="12" class3="13"/>
+<UreyBradley k="5490.126000594899" d="0.21651894884220924" class1="11" class2="12" class3="25"/>
+<UreyBradley k="5490.126000594899" d="0.21651894884220924" class1="11" class2="12" class3="26"/>
+<UreyBradley k="5774.730187665729" d="0.21661802925246817" class1="12" class2="11" class3="23"/>
+<UreyBradley k="5774.730187665729" d="0.21661802925246817" class1="12" class2="11" class3="24"/>
+<UreyBradley k="17499.632069206345" d="0.2454186379331869" class1="12" class2="13" class3="14"/>
+<UreyBradley k="5953.844911577077" d="0.21661401961453586" class1="12" class2="13" class3="27"/>
+<UreyBradley k="5953.844911577077" d="0.21661401961453586" class1="12" class2="13" class3="28"/>
+<UreyBradley k="6542.009418615899" d="0.21452792982373092" class1="13" class2="12" class3="25"/>
+<UreyBradley k="6542.009418615899" d="0.21452792982373092" class1="13" class2="12" class3="26"/>
+<UreyBradley k="2822.383562779584" d="0.2477838086895217" class1="13" class2="14" class3="15"/>
+<UreyBradley k="12708.844462771869" d="0.24586309792299163" class1="13" class2="14" class3="21"/>
+<UreyBradley k="11785.513551294041" d="0.20836612491682935" class1="14" class2="13" class3="27"/>
+<UreyBradley k="11785.513551294041" d="0.20836612491682935" class1="14" class2="13" class3="28"/>
+<UreyBradley k="16719.37833648016" d="0.2461210168751435" class1="14" class2="15" class3="16"/>
+<UreyBradley k="11785.513551294041" d="0.20836612491682935" class1="14" class2="15" class3="29"/>
+<UreyBradley k="11785.513551294041" d="0.20836612491682935" class1="14" class2="15" class3="30"/>
+<UreyBradley k="23374.60254081932" d="0.24297788191575914" class1="14" class2="21" class3="18"/>
+<UreyBradley k="12708.844462771869" d="0.24586309792299163" class1="15" class2="14" class3="21"/>
+<UreyBradley k="16109.050664759145" d="0.24828371990244094" class1="15" class2="16" class3="17"/>
+<UreyBradley k="6673.048039671322" d="0.21464121187011923" class1="15" class2="16" class3="31"/>
+<UreyBradley k="6673.048039671322" d="0.21464121187011923" class1="15" class2="16" class3="32"/>
+<UreyBradley k="5565.218138423837" d="0.21644638235158423" class1="16" class2="15" class3="29"/>
+<UreyBradley k="5565.218138423837" d="0.21644638235158423" class1="16" class2="15" class3="30"/>
+<UreyBradley k="11426.230932217213" d="0.24963393491426134" class1="16" class2="17" class3="18"/>
+<UreyBradley k="6140.208062609391" d="0.2161762029130787" class1="16" class2="17" class3="33"/>
+<UreyBradley k="6140.208062609391" d="0.2161762029130787" class1="16" class2="17" class3="34"/>
+<UreyBradley k="5430.500559009697" d="0.21671848266256852" class1="17" class2="16" class3="31"/>
+<UreyBradley k="5430.500559009697" d="0.21671848266256852" class1="17" class2="16" class3="32"/>
+<UreyBradley k="8964.153219385402" d="0.2503562287179003" class1="17" class2="18" class3="19"/>
+<UreyBradley k="8643.211388201846" d="0.2548454752810531" class1="17" class2="18" class3="21"/>
+<UreyBradley k="8972.360607646511" d="0.21400564848019976" class1="18" class2="17" class3="33"/>
+<UreyBradley k="8972.360607646511" d="0.21400564848019976" class1="18" class2="17" class3="34"/>
+<UreyBradley k="31223.750330411996" d="0.2449980098005106" class1="18" class2="19" class3="20"/>
+<UreyBradley k="5025.545335281098" d="0.21188905925070795" class1="18" class2="19" class3="35"/>
+<UreyBradley k="23484.410915818764" d="0.2421162792551893" class1="19" class2="18" class3="21"/>
+<UreyBradley k="3801.2066908477314" d="0.21585169241853103" class1="20" class2="19" class3="35"/>
+<UreyBradley k="7096.95512686601" d="0.17455161176521647" class1="23" class2="11" class3="24"/>
+<UreyBradley k="6704.434604327956" d="0.17659145737057536" class1="25" class2="12" class3="26"/>
+<UreyBradley k="6687.501314813846" d="0.1768878357199081" class1="27" class2="13" class3="28"/>
+<UreyBradley k="6687.501314813846" d="0.1768878357199081" class1="29" class2="15" class3="30"/>
+<UreyBradley k="6625.20883860628" d="0.17669982064045128" class1="31" class2="16" class3="32"/>
+<UreyBradley k="7069.036177527265" d="0.17561999811379547" class1="33" class2="17" class3="34"/>
+</AmoebaUreyBradleyForce>
 <PeriodicTorsionForce ordering="charmm">
-<Proper k1="1.348341789888e-06" k2="-1.820904150913" k3="0.5351678631021" k4="1.563408120152e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="1.144304892039e-06" k2="7.076782253633e-07" k3="-0.138829387054" k4="1.249952962539e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="6.884409781285929" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="1.348341789888e-06" k2="-1.820904150913" k3="0.5351678631021" k4="1.563408120152e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="1.144304892039e-06" k2="7.076782253633e-07" k3="-0.138829387054" k4="1.249952962539e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="1.348341789888e-06" k2="-1.820904150913" k3="0.5351678631021" k4="1.563408120152e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="1.144304892039e-06" k2="7.076782253633e-07" k3="-0.138829387054" k4="1.249952962539e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="41.712313613922674" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="27.756279124621436" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="21.87469044804102" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="17.086239232531707" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="16.049713995783524" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.907611303678394" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="6.442495744198161" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="22.96421643373444" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="33.27014806952481" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="4.10840466897872" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="17.499129950021295" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="26.270245217347323" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="19.94217524128072" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="12.808110545224359" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="5.57231431329095" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="19.662593867070797" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="18.523050878073647" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="10.372977673773924" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="3.448103044540135" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="42.48394016203459" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="37.71490470107013" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="32.066802813188545" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="12.926589324524048" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="28.99469588194804" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="9.29278557584628" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="17.088358897324614" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.608501358584917" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.2698248537965008" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="18.630261910644048" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="11.986781585555482" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="14.062611534956037" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="10.195090476608799" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="3.0482890469221494e-22" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="1.4401493126704753e-24" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="7.112732600273818e-24" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="1.277746681070373e-28" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="5.5414820130525485e-24" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="6.884409781274203" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="1.3083862441319007e-30" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="6.71151389249218e-27" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="41.712313614254136" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="27.756279125114" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="33.27014806967192" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="17.499129949358096" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="6.44249574475584" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="4.10840466977529" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="22.96421643402928" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="1.0854871748589555e-23" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="26.270245217107576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="8.242659952208218e-12" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="32.0668028130294" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="14.062611534958192" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="21.874690447839594" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="19.942175240568773" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="17.08623923254279" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="10.37297767382078" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="9.292785575446251" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="12.808110545320897" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="5.572314313355817" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="12.92658932515868" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="28.994695882244578" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="3.448103044110489" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="10"/>
+<Proper k1="0" k2="0.26982485370104203" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="18.630261910804172" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="11.986781585457306" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="7.214606294789286e-26" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="10.19509047645888" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="42.48394016173962" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="17.088358897467092" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="37.71490470084306" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="15.60850135855337" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="16.04971399582435" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="19.662593867162265" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="9"/>
+<Proper k1="0" k2="15.907611303736608" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="18.52305087820756" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="9"/>
+<Proper k1="1.362429701294e-06" k2="-1.820903925405" k3="0.6817071874584" k4="4.613822488758e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="1.169874438744e-06" k2="4.860499409111e-07" k3="-0.1388320178575" k4="1.426091249731e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="1.362429701294e-06" k2="-1.820903925405" k3="0.6817071874584" k4="4.613822488758e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="1.169874438744e-06" k2="4.860499409111e-07" k3="-0.1388320178575" k4="1.426091249731e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.362429701294e-06" k2="-1.820903925405" k3="0.6817071874584" k4="4.613822488758e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="1.169874438744e-06" k2="4.860499409111e-07" k3="-0.1388320178575" k4="1.426091249731e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
 </PeriodicTorsionForce>
 <RBTorsionForce>
-<Proper c0="12.956" c1="38.805" c2="29.057" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
-<Proper c0="21.711" c1="81.466" c2="76.423" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
-<Proper c0="27.018" c1="69.607" c2="44.832" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
-<Proper c0="24.334" c1="89.085" c2="81.534" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
-<Proper c0="4.592" c1="14.777" c2="11.889" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
-<Proper c0="35.585" c1="86.714" c2="52.826" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
-<Proper c0="126.316" c1="279.33" c2="154.425" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="17" class3="18" class4="21"/>
+<Proper c0="12.956" c1="38.805" c2="29.057" c3="0" c4="0" c5="0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.711" c1="81.466" c2="76.423" c3="0" c4="0" c5="0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="27.018" c1="69.607" c2="44.832" c3="0" c4="0" c5="0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="35.585" c1="86.714" c2="52.826" c3="0" c4="0" c5="0" class1="21" class2="14" class3="15" class4="16"/>
+<Proper c0="24.334" c1="89.085" c2="81.534" c3="0" c4="0" c5="0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="4.592" c1="14.777" c2="11.889" c3="0" c4="0" c5="0" class1="15" class2="16" class3="17" class4="18"/>
+<Proper c0="126.316" c1="279.33" c2="154.425" c3="0" c4="0" c5="0" class1="16" class2="17" class3="18" class4="21"/>
 </RBTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
 <Atom charge="-0.264836" epsilon="0.24454981151424124" sigma="0.2992019647933705" type="QUBE_0"/>
@@ -471,7 +411,7 @@
 <Atom charge="0.100277" epsilon="0.0834669438818803" sigma="0.24089722551435258" type="QUBE_32"/>
 <Atom charge="0.106005" epsilon="0.08392405597588261" sigma="0.24188256083188234" type="QUBE_33"/>
 <Atom charge="0.106005" epsilon="0.08392405597588261" sigma="0.24188256083188234" type="QUBE_34"/>
-<Atom charge="0.12477" epsilon="0.08801330957484484" sigma="0.2506380050397751" type="QUBE_35"/>
+<Atom charge="0.124770" epsilon="0.08801330957484484" sigma="0.2506380050397751" type="QUBE_35"/>
 <Atom charge="-0.059761" epsilon="0" sigma="1" type="v-site1"/>
 <Atom charge="-0.059761" epsilon="0" sigma="1" type="v-site2"/>
 </NonbondedForce>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-modsem-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-modsem-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1" Date="2022_03_03"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -119,9 +119,9 @@
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13496011742992933" k="259586.48572299856" class1="0" class2="1"/>
-<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="2"/>
-<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="3"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="0" class2="1"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="1" class2="2"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="1" class2="3"/>
 <Bond length="0.15089307265750462" k="205802.9322041371" class1="1" class2="4"/>
 <Bond length="0.13479954466568161" k="460185.44749956" class1="4" class2="5"/>
 <Bond length="0.14424155029894592" k="249691.30512503046" class1="4" class2="20"/>
@@ -162,229 +162,230 @@
 <HarmonicAngleForce>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
-<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
-<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
-<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
 <Angle k="849.9711499843376" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
 <Angle k="849.9711499843376" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
 <Angle k="639.7476858128786" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
 <Angle k="262.3563023615395" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
-<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
-<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
-<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
 <Angle k="557.4746848468715" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
 <Angle k="807.9095983882028" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
-<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
-<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
 <Angle k="552.9254852453236" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
 <Angle k="751.8116762302967" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
 <Angle k="718.830040433039" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
 <Angle k="553.7538746695924" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
 <Angle k="648.9592299042741" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
-<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
-<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
 <Angle k="1121.6908591863469" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
 <Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
 <Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
-<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
-<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
-<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
 <Angle k="795.9032365496385" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
 <Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
 <Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
-<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
-<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
+<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
 <Angle k="1061.3339489822274" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
 <Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
 <Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
-<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
-<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
-<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
-<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
 <Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="27"/>
 <Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="28"/>
+<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
+<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
+<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
 <Angle k="1043.2371059142824" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
 <Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="29"/>
 <Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="30"/>
-<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
-<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
 <Angle k="1017.6871864118357" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
 <Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
 <Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
-<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
-<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
 <Angle k="1173.139818868356" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
 <Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
 <Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
-<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
-<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
-<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
-<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
 <Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
 <Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
 <Angle k="700.965705603468" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
 <Angle k="282.6287693615428" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
-<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
 <Angle k="264.5571241818087" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
-<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
-<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
-<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
-<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
-<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
-<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce/>
 <PeriodicTorsionForce ordering="smirnoff">
-<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="1.07556741849e-06" k2="-1.820903930831" k3="-0.7896462582336" k4="1.151430560008e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="9.571589060911e-07" k2="1.063641602339e-06" k3="-0.5096697762873" k4="1.068380470931e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+<Proper k1="1.004755979347e-06" k2="-1.820903684658" k3="-0.7610064895027" k4="9.073093666641e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="1.043135473309e-06" k2="1.585197093026e-06" k3="-0.4561671084673" k4="1.261596351016e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="1.004755979347e-06" k2="-1.820903684658" k3="-0.7610064895027" k4="9.073093666641e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="1.043135473309e-06" k2="1.585197093026e-06" k3="-0.4561671084673" k4="1.261596351016e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.004755979347e-06" k2="-1.820903684658" k3="-0.7610064895027" k4="9.073093666641e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="1.043135473309e-06" k2="1.585197093026e-06" k3="-0.4561671084673" k4="1.261596351016e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
 </PeriodicTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
-<Atom charge="-0.25233" epsilon="0.26146577464789816" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_0"/>
 <Atom charge="0.776573" epsilon="0.2732087688406762" sigma="0.3089811804362698" type="QUBE_1"/>
-<Atom charge="-0.242744" epsilon="0.2601425350261072" sigma="0.29666886791766617" type="QUBE_2"/>
-<Atom charge="-0.251133" epsilon="0.2614064687902009" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_2"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_3"/>
 <Atom charge="-0.051181" epsilon="0.3114224736729138" sigma="0.34366343352476914" type="QUBE_4"/>
 <Atom charge="-0.303105" epsilon="0.32369222426161337" sigma="0.3546262114386765" type="QUBE_5"/>
 <Atom charge="0.667684" epsilon="0.273086823211064" sigma="0.3088691064321672" type="QUBE_6"/>
-<Atom charge="-0.56416" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
+<Atom charge="-0.564160" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
 <Atom charge="-0.266561" epsilon="0.6874490135799819" sigma="0.27383444348429714" type="QUBE_8"/>
 <Atom charge="0.227775" epsilon="0.2970905744228003" sigma="0.33075499678354847" type="QUBE_9"/>
 <Atom charge="-0.120378" epsilon="0.3152955026616835" sigma="0.34713250572596427" type="QUBE_10"/>
@@ -400,18 +401,18 @@
 <Atom charge="-0.078422" epsilon="0.3156767824810448" sigma="0.3474735849213942" type="QUBE_20"/>
 <Atom charge="0.155012" epsilon="0.30132283520205017" sigma="0.3345788062188248" type="QUBE_21"/>
 <Atom charge="0.167521" epsilon="0.0978107710473215" sigma="0.23811289791476886" type="QUBE_22"/>
-<Atom charge="0.097355" epsilon="0.10056024578458915" sigma="0.24353785483009005" type="QUBE_23"/>
-<Atom charge="0.090775" epsilon="0.1012671279779549" sigma="0.24492807935732094" type="QUBE_24"/>
-<Atom charge="0.091394" epsilon="0.10002118610996971" sigma="0.24247645596416315" type="QUBE_25"/>
-<Atom charge="0.095147" epsilon="0.09768974390991514" sigma="0.2378734492279842" type="QUBE_26"/>
-<Atom charge="0.078988" epsilon="0.10050647116630629" sigma="0.24343202152984458" type="QUBE_27"/>
-<Atom charge="0.061498" epsilon="0.10369430117364004" sigma="0.24968785757653836" type="QUBE_28"/>
-<Atom charge="0.079282" epsilon="0.10037122656954406" sigma="0.24316580104266824" type="QUBE_29"/>
-<Atom charge="0.06061" epsilon="0.1036603620040513" sigma="0.2496214465559107" type="QUBE_30"/>
-<Atom charge="0.093159" epsilon="0.1001076810033671" sigma="0.24264683492102518" type="QUBE_31"/>
-<Atom charge="0.096345" epsilon="0.09777800648277413" sigma="0.23804807965605482" type="QUBE_32"/>
-<Atom charge="0.096629" epsilon="0.09882519092751813" sigma="0.24011772344082505" type="QUBE_33"/>
-<Atom charge="0.087509" epsilon="0.1010563421031184" sigma="0.24451371781920664" type="QUBE_34"/>
-<Atom charge="0.113031" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
+<Atom charge="0.094065" epsilon="0.10091457682034005" sigma="0.24423494543901622" type="QUBE_23"/>
+<Atom charge="0.094065" epsilon="0.10091457682034005" sigma="0.24423494543901622" type="QUBE_24"/>
+<Atom charge="0.093270" epsilon="0.09886534679264636" sigma="0.24019700498485672" type="QUBE_25"/>
+<Atom charge="0.093270" epsilon="0.09886534679264636" sigma="0.24019700498485672" type="QUBE_26"/>
+<Atom charge="0.070243" epsilon="0.10211827266242138" sigma="0.24659961468037703" type="QUBE_27"/>
+<Atom charge="0.070243" epsilon="0.10211827266242138" sigma="0.24659961468037703" type="QUBE_28"/>
+<Atom charge="0.069946" epsilon="0.10203485128906832" sigma="0.2464359018909392" type="QUBE_29"/>
+<Atom charge="0.069946" epsilon="0.10203485128906832" sigma="0.2464359018909392" type="QUBE_30"/>
+<Atom charge="0.094752" epsilon="0.09895270183569954" sigma="0.2403694531678513" type="QUBE_31"/>
+<Atom charge="0.094752" epsilon="0.09895270183569954" sigma="0.2403694531678513" type="QUBE_32"/>
+<Atom charge="0.092069" epsilon="0.09994971821223084" sigma="0.2423356565804284" type="QUBE_33"/>
+<Atom charge="0.092069" epsilon="0.09994971821223084" sigma="0.2423356565804284" type="QUBE_34"/>
+<Atom charge="0.113033" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
 </NonbondedForce>
 </ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-qcforce-ub-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-qcforce-ub-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -116,333 +116,268 @@
 <Bond from="18" to="21"/>
 <Bond from="19" to="20"/>
 <Bond from="19" to="35"/>
-<Bond from="0" to="2"/>
-<Bond from="0" to="3"/>
-<Bond from="0" to="4"/>
-<Bond from="1" to="5"/>
-<Bond from="1" to="20"/>
-<Bond from="2" to="3"/>
-<Bond from="2" to="4"/>
-<Bond from="3" to="4"/>
-<Bond from="4" to="6"/>
-<Bond from="4" to="22"/>
-<Bond from="4" to="9"/>
-<Bond from="4" to="19"/>
-<Bond from="5" to="20"/>
-<Bond from="5" to="7"/>
-<Bond from="5" to="8"/>
-<Bond from="6" to="22"/>
-<Bond from="6" to="9"/>
-<Bond from="7" to="8"/>
-<Bond from="8" to="10"/>
-<Bond from="8" to="20"/>
-<Bond from="9" to="11"/>
-<Bond from="9" to="21"/>
-<Bond from="9" to="19"/>
-<Bond from="10" to="20"/>
-<Bond from="10" to="12"/>
-<Bond from="10" to="23"/>
-<Bond from="10" to="24"/>
-<Bond from="10" to="14"/>
-<Bond from="10" to="18"/>
-<Bond from="11" to="21"/>
-<Bond from="11" to="13"/>
-<Bond from="11" to="25"/>
-<Bond from="11" to="26"/>
-<Bond from="12" to="23"/>
-<Bond from="12" to="24"/>
-<Bond from="12" to="14"/>
-<Bond from="12" to="27"/>
-<Bond from="12" to="28"/>
-<Bond from="13" to="25"/>
-<Bond from="13" to="26"/>
-<Bond from="13" to="15"/>
-<Bond from="13" to="21"/>
-<Bond from="14" to="27"/>
-<Bond from="14" to="28"/>
-<Bond from="14" to="16"/>
-<Bond from="14" to="29"/>
-<Bond from="14" to="30"/>
-<Bond from="14" to="18"/>
-<Bond from="15" to="21"/>
-<Bond from="15" to="17"/>
-<Bond from="15" to="31"/>
-<Bond from="15" to="32"/>
-<Bond from="16" to="29"/>
-<Bond from="16" to="30"/>
-<Bond from="16" to="18"/>
-<Bond from="16" to="33"/>
-<Bond from="16" to="34"/>
-<Bond from="17" to="31"/>
-<Bond from="17" to="32"/>
-<Bond from="17" to="19"/>
-<Bond from="17" to="21"/>
-<Bond from="18" to="33"/>
-<Bond from="18" to="34"/>
-<Bond from="18" to="20"/>
-<Bond from="18" to="35"/>
-<Bond from="19" to="21"/>
-<Bond from="20" to="35"/>
-<Bond from="23" to="24"/>
-<Bond from="25" to="26"/>
-<Bond from="27" to="28"/>
-<Bond from="29" to="30"/>
-<Bond from="31" to="32"/>
-<Bond from="33" to="34"/>
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13469356407442745" k="248696.12934885127" class1="0" class2="1"/>
-<Bond length="0.13469356407442745" k="248696.12934885127" class1="1" class2="2"/>
-<Bond length="0.13469356407442745" k="248696.12934885127" class1="1" class2="3"/>
-<Bond length="0.15089307265750462" k="218544.0885900748" class1="1" class2="4"/>
-<Bond length="0.13479954466568161" k="452409.97449639573" class1="4" class2="5"/>
-<Bond length="0.14424155029894592" k="235616.92931297317" class1="4" class2="20"/>
-<Bond length="0.14564591082883707" k="213431.4378351508" class1="5" class2="6"/>
-<Bond length="0.10814511275621548" k="336932.01010267145" class1="5" class2="22"/>
-<Bond length="0.12065331189134901" k="697056.894846477" class1="6" class2="7"/>
-<Bond length="0.13738032210105275" k="171032.87641743006" class1="6" class2="8"/>
-<Bond length="0.13688031490221975" k="245764.7620565325" class1="8" class2="9"/>
-<Bond length="0.13896874772055995" k="301499.83087445924" class1="9" class2="10"/>
-<Bond length="0.14002870254626093" k="278597.1473880633" class1="9" class2="20"/>
-<Bond length="0.15105020854333961" k="197686.8752677544" class1="10" class2="11"/>
-<Bond length="0.14097123172598094" k="266870.6670559599" class1="10" class2="21"/>
-<Bond length="0.15240838998674713" k="188853.87239804704" class1="11" class2="12"/>
-<Bond length="0.10957700046070398" k="298213.74000018986" class1="11" class2="23"/>
-<Bond length="0.10957700046070398" k="298213.74000018986" class1="11" class2="24"/>
-<Bond length="0.15195279246806304" k="190828.67966440998" class1="12" class2="13"/>
-<Bond length="0.1095362671842942" k="299378.38173584116" class1="12" class2="25"/>
-<Bond length="0.1095362671842942" k="299378.38173584116" class1="12" class2="26"/>
-<Bond length="0.14540284161875516" k="204754.08956276052" class1="13" class2="14"/>
-<Bond length="0.10990907747815233" k="289809.04755993414" class1="13" class2="27"/>
-<Bond length="0.10990907747815233" k="289809.04755993414" class1="13" class2="28"/>
-<Bond length="0.14540284161875516" k="204754.08956276052" class1="14" class2="15"/>
-<Bond length="0.1382504797109479" k="275055.1221468047" class1="14" class2="21"/>
-<Bond length="0.15197197918433358" k="190569.04382625862" class1="15" class2="16"/>
-<Bond length="0.10990907747815233" k="289809.04755993414" class1="15" class2="29"/>
-<Bond length="0.10990907747815233" k="289809.04755993414" class1="15" class2="30"/>
-<Bond length="0.15233937621320012" k="188400.8899591935" class1="16" class2="17"/>
-<Bond length="0.10954484075537119" k="299020.7928388245" class1="16" class2="31"/>
-<Bond length="0.10954484075537119" k="299020.7928388245" class1="16" class2="32"/>
-<Bond length="0.15125045314560479" k="200506.13850190217" class1="17" class2="18"/>
-<Bond length="0.10968207551426526" k="295027.9665962813" class1="17" class2="33"/>
-<Bond length="0.10968207551426526" k="295027.9665962813" class1="17" class2="34"/>
-<Bond length="0.13769965673158013" k="349377.2659826007" class1="18" class2="19"/>
-<Bond length="0.14239910645593554" k="236685.3977535236" class1="18" class2="21"/>
-<Bond length="0.14040346349188373" k="290384.285293299" class1="19" class2="20"/>
-<Bond length="0.1084526136401619" k="332068.7475784242" class1="19" class2="35"/>
-<Bond length="0.21652967675118645" k="65815.81802630179" class1="0" class2="2"/>
-<Bond length="0.21652967675118645" k="65815.81802630179" class1="0" class2="3"/>
-<Bond length="0.2367308754593913" k="34649.92669158233" class1="0" class2="4"/>
-<Bond length="0.24637183735463966" k="22668.12122489944" class1="1" class2="5"/>
-<Bond length="0.2552484693842637" k="33041.46692529321" class1="1" class2="20"/>
-<Bond length="0.21652967675118645" k="65815.81802630179" class1="2" class2="3"/>
-<Bond length="0.2367308754593913" k="34649.92669158233" class1="2" class2="4"/>
-<Bond length="0.2367308754593913" k="34649.92669158233" class1="3" class2="4"/>
-<Bond length="0.24424950724834102" k="33454.2998491019" class1="4" class2="6"/>
-<Bond length="0.2137728474468069" k="14245.085810712015" class1="4" class2="22"/>
-<Bond length="0.24235320460628298" k="29235.77324721258" class1="4" class2="9"/>
-<Bond length="0.25380961300478017" k="38071.000612605276" class1="4" class2="19"/>
-<Bond length="0.24317848563613786" k="48937.59397074284" class1="5" class2="20"/>
-<Bond length="0.23691569131052775" k="62517.08343169539" class1="5" class2="7"/>
-<Bond length="0.2404062775308595" k="35515.642919775084" class1="5" class2="8"/>
-<Bond length="0.21616921612132547" k="16817.64582074077" class1="6" class2="22"/>
-<Bond length="0.24155207989996136" k="43514.91376185767" class1="6" class2="9"/>
-<Bond length="0.22173066563125332" k="94829.60574869142" class1="7" class2="8"/>
-<Bond length="0.23348443062234248" k="57621.033943389804" class1="8" class2="10"/>
-<Bond length="0.2409996256628092" k="33101.49253486298" class1="8" class2="20"/>
-<Bond length="0.2508615762103375" k="19476.432640405463" class1="9" class2="11"/>
-<Bond length="0.2403603662334068" k="49292.67773448853" class1="9" class2="21"/>
-<Bond length="0.23893622663484204" k="44594.43403948841" class1="9" class2="19"/>
-<Bond length="0.24561151969819398" k="39645.792636160666" class1="10" class2="20"/>
-<Bond length="0.25043517668197823" k="20362.7363655314" class1="10" class2="12"/>
-<Bond length="0.2143215696888813" k="17514.030354806964" class1="10" class2="23"/>
-<Bond length="0.2143215696888813" k="17514.030354806964" class1="10" class2="24"/>
-<Bond length="0.24191336629679144" k="47149.986141393405" class1="10" class2="14"/>
-<Bond length="0.2449311721801657" k="41833.34357064601" class1="10" class2="18"/>
-<Bond length="0.2554238649411517" k="15110.572323934382" class1="11" class2="21"/>
-<Bond length="0.24943515144206752" k="31166.724741526126" class1="11" class2="13"/>
-<Bond length="0.21638649819857225" k="11482.814271086178" class1="11" class2="25"/>
-<Bond length="0.21638649819857225" k="11482.814271086178" class1="11" class2="26"/>
-<Bond length="0.21637698760602225" k="11875.34822029003" class1="12" class2="23"/>
-<Bond length="0.21637698760602225" k="11875.34822029003" class1="12" class2="24"/>
-<Bond length="0.2445664336412628" k="32697.295592576887" class1="12" class2="14"/>
-<Bond length="0.21627463620927637" k="11582.775159333945" class1="12" class2="27"/>
-<Bond length="0.21627463620927637" k="11582.775159333945" class1="12" class2="28"/>
-<Bond length="0.2146925734975977" k="13456.42635345173" class1="13" class2="25"/>
-<Bond length="0.2146925734975977" k="13456.42635345173" class1="13" class2="26"/>
-<Bond length="0.2466018129470507" k="3645.036085047076" class1="13" class2="15"/>
-<Bond length="0.24530456727951677" k="25381.47463105833" class1="13" class2="21"/>
-<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="27"/>
-<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="28"/>
-<Bond length="0.24506286921679699" k="32714.429307871946" class1="14" class2="16"/>
-<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="29"/>
-<Bond length="0.20904668083340297" k="23036.1769080387" class1="14" class2="30"/>
-<Bond length="0.24341685186846426" k="45704.36250778908" class1="14" class2="18"/>
-<Bond length="0.24530456727951677" k="25381.47463105833" class1="15" class2="21"/>
-<Bond length="0.2482899688867673" k="30243.829665329897" class1="15" class2="17"/>
-<Bond length="0.21482896649717576" k="13727.239961651174" class1="15" class2="31"/>
-<Bond length="0.21482896649717576" k="13727.239961651174" class1="15" class2="32"/>
-<Bond length="0.2161210191868845" k="10803.416482315797" class1="16" class2="29"/>
-<Bond length="0.2161210191868845" k="10803.416482315797" class1="16" class2="30"/>
-<Bond length="0.25071186281720664" k="20777.32383702234" class1="16" class2="18"/>
-<Bond length="0.21588768954068127" k="12426.545442223944" class1="16" class2="33"/>
-<Bond length="0.21588768954068127" k="12426.545442223944" class1="16" class2="34"/>
-<Bond length="0.2166014429827969" k="11766.726405139507" class1="17" class2="31"/>
-<Bond length="0.2166014429827969" k="11766.726405139507" class1="17" class2="32"/>
-<Bond length="0.2501622513015905" k="13594.569383728967" class1="17" class2="19"/>
-<Bond length="0.25504206857818595" k="16625.350647412968" class1="17" class2="21"/>
-<Bond length="0.2145767289449851" k="14970.96386176797" class1="18" class2="33"/>
-<Bond length="0.2145767289449851" k="14970.96386176797" class1="18" class2="34"/>
-<Bond length="0.24352193235081798" k="52118.294889790704" class1="18" class2="20"/>
-<Bond length="0.21177124922411472" k="7990.287381239743" class1="18" class2="35"/>
-<Bond length="0.24207073997933107" k="52699.921136539124" class1="19" class2="21"/>
-<Bond length="0.21560948327565438" k="10649.532635033214" class1="20" class2="35"/>
-<Bond length="0.17462080461979723" k="13731.15742367687" class1="23" class2="24"/>
-<Bond length="0.17661650584198943" k="13427.247612635645" class1="25" class2="26"/>
-<Bond length="0.17685797959042412" k="13157.926302512604" class1="27" class2="28"/>
-<Bond length="0.17685797959042412" k="13157.926302512604" class1="29" class2="30"/>
-<Bond length="0.1767871797367549" k="13264.20081532144" class1="31" class2="32"/>
-<Bond length="0.17560269028929812" k="13781.081713223526" class1="33" class2="34"/>
+<Bond length="0.13469356407442745" k="248688.55170044038" class1="0" class2="1"/>
+<Bond length="0.13469356407442745" k="248688.55170044038" class1="1" class2="2"/>
+<Bond length="0.13469356407442745" k="248688.55170044038" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="218523.66201433638" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="452409.136527761" class1="4" class2="5"/>
+<Bond length="0.1442415502989459" k="235621.02114965697" class1="4" class2="20"/>
+<Bond length="0.14564591082883702" k="213450.8886068404" class1="5" class2="6"/>
+<Bond length="0.10814511275621547" k="336931.50427574175" class1="5" class2="22"/>
+<Bond length="0.12065331189134898" k="697055.0742988772" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="171016.28460592916" class1="6" class2="8"/>
+<Bond length="0.13688031490221972" k="245771.97055103298" class1="8" class2="9"/>
+<Bond length="0.13896874772055998" k="301499.4415699993" class1="9" class2="10"/>
+<Bond length="0.14002870254626087" k="278601.4488810301" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="197697.75078965598" class1="10" class2="11"/>
+<Bond length="0.140971231725981" k="266858.5942910334" class1="10" class2="21"/>
+<Bond length="0.1524083899867472" k="188860.19755348092" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="298208.49187359615" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="298208.49187359615" class1="11" class2="24"/>
+<Bond length="0.15195279246806304" k="190831.94330058503" class1="12" class2="13"/>
+<Bond length="0.10953626718429424" k="299373.20648494805" class1="12" class2="25"/>
+<Bond length="0.10953626718429424" k="299373.20648494805" class1="12" class2="26"/>
+<Bond length="0.14540284161875516" k="204812.73213388436" class1="13" class2="14"/>
+<Bond length="0.10990907747815233" k="289821.7177147197" class1="13" class2="27"/>
+<Bond length="0.10990907747815233" k="289821.7177147197" class1="13" class2="28"/>
+<Bond length="0.14540284161875516" k="204812.73213388436" class1="14" class2="15"/>
+<Bond length="0.13825047971094792" k="275070.4102305632" class1="14" class2="21"/>
+<Bond length="0.15197197918433358" k="190578.1724907198" class1="15" class2="16"/>
+<Bond length="0.10990907747815233" k="289821.7177147197" class1="15" class2="29"/>
+<Bond length="0.10990907747815233" k="289821.7177147197" class1="15" class2="30"/>
+<Bond length="0.15233937621320007" k="188419.76376492775" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="299014.6433395" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="299014.6433395" class1="16" class2="32"/>
+<Bond length="0.15125045314560479" k="200529.6246479712" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="295025.9779771505" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="295025.9779771505" class1="17" class2="34"/>
+<Bond length="0.13769965673158016" k="349375.6933595531" class1="18" class2="19"/>
+<Bond length="0.14239910645593554" k="236671.59676759003" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="290353.57949453936" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="332078.08997643227" class1="19" class2="35"/>
 </HarmonicBondForce>
 <HarmonicAngleForce>
-<Angle k="634.9590563926183" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
-<Angle k="634.9590563926183" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
-<Angle k="531.6283246477715" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
-<Angle k="412.2136427606707" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
-<Angle k="135.54119603796627" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
-<Angle k="634.9590563926183" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
-<Angle k="531.6283246477715" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
-<Angle k="531.6283246477715" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
-<Angle k="587.6431955844229" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
-<Angle k="246.56202758152673" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
-<Angle k="546.1164982034062" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
-<Angle k="678.8281698124405" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
-<Angle k="98.1305991319774" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
-<Angle k="249.07204008402334" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
-<Angle k="110.74533271318298" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
-<Angle k="213.61856334435936" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
-<Angle k="478.1225794840239" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
-<Angle k="769.3256680451444" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
-<Angle k="660.1215176306495" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
-<Angle k="431.47694830279323" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
-<Angle k="317.636853594348" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
-<Angle k="395.23989766599817" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
-<Angle k="304.4342257281013" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
-<Angle k="100.97743152622468" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
-<Angle k="400.6374482905871" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
-<Angle k="296.6240561074525" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
-<Angle k="296.6240561074525" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
-<Angle k="597.6626799748337" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
-<Angle k="105.72056959700619" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
-<Angle k="417.8642188947819" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
-<Angle k="602.3931784157377" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
-<Angle k="354.7074021223168" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
-<Angle k="354.7074021223168" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
-<Angle k="347.97195187859677" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
-<Angle k="347.97195187859677" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
-<Angle k="518.3047196834742" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
-<Angle k="351.845036413452" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
-<Angle k="351.845036413452" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
-<Angle k="342.61733009725106" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
-<Angle k="342.61733009725106" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
-<Angle k="626.6335617498364" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
-<Angle k="332.3549732351152" angle="2.0891509949808236" class1="13" class2="14" class3="21"/>
-<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
-<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
-<Angle k="510.6224013201775" angle="1.9368432495236967" class1="14" class2="15" class3="16"/>
-<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
-<Angle k="361.0292393216943" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
-<Angle k="615.3944381689575" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
-<Angle k="332.3549732351152" angle="2.0891509949808236" class1="15" class2="14" class3="21"/>
-<Angle k="612.9457825256006" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
-<Angle k="343.6090714215259" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
-<Angle k="343.6090714215259" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
-<Angle k="358.2972870917604" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
-<Angle k="358.2972870917604" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
-<Angle k="372.21383486807724" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
-<Angle k="353.09489772399587" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
-<Angle k="353.09489772399587" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
-<Angle k="361.5328323378854" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
-<Angle k="361.5328323378854" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
-<Angle k="540.4710511015742" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
-<Angle k="414.9682578497672" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
-<Angle k="299.28391787230015" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
-<Angle k="299.28391787230015" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
-<Angle k="219.76942365478908" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
-<Angle k="325.34270240972637" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
-<Angle k="371.7109226596257" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
-<Angle k="190.2700655022649" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
-<Angle k="261.8215738578441" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
-<Angle k="270.01472283443877" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
-<Angle k="260.09441925250667" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
-<Angle k="260.09441925250667" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
-<Angle k="266.4399402887101" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
-<Angle k="273.1212697604543" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="635.0442853828736" angle="1.8672649914285964" class1="0" class2="1" class3="2"/>
+<Angle k="635.0442853828736" angle="1.8672649914285964" class1="0" class2="1" class3="3"/>
+<Angle k="531.7472968864736" angle="1.9522011286394667" class1="0" class2="1" class3="4"/>
+<Angle k="412.1233493559381" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="135.4982954331972" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="635.0442853828736" angle="1.8672649914285964" class1="2" class2="1" class3="3"/>
+<Angle k="531.7472968864736" angle="1.9522011286394667" class1="2" class2="1" class3="4"/>
+<Angle k="531.7472968864736" angle="1.9522011286394667" class1="3" class2="1" class3="4"/>
+<Angle k="587.7235644669352" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="246.8699595639561" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="546.235060511171" angle="2.041536638744443" class1="4" class2="20" class3="9"/>
+<Angle k="678.9471467628425" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="97.93488016652857" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="249.03187006890468" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="110.77465001452401" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="213.60776239194092" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="477.95801888074567" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="769.3059930155205" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="660.0636321186336" angle="2.0184198324929112" class1="8" class2="9" class3="10"/>
+<Angle k="431.46424797380695" angle="2.111632752598201" class1="8" class2="9" class3="20"/>
+<Angle k="317.5897274130497" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="395.38313351272285" angle="2.065088732327609" class1="9" class2="10" class3="21"/>
+<Angle k="304.4617552121914" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="100.94816481615786" angle="2.1531326743843784" class1="10" class2="9" class3="20"/>
+<Angle k="400.4659450773686" angle="1.9413453751779066" class1="10" class2="11" class3="12"/>
+<Angle k="296.5485128091721" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="296.5485128091721" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="597.5024049002756" angle="2.0957777004398195" class1="10" class2="21" class3="14"/>
+<Angle k="105.4590945763043" angle="2.0876983232001356" class1="10" class2="21" class3="18"/>
+<Angle k="417.9180957000005" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="602.7391541838255" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="354.7453599369072" angle="1.9255116484664123" class1="11" class2="12" class3="25"/>
+<Angle k="354.7453599369072" angle="1.9255116484664123" class1="11" class2="12" class3="26"/>
+<Angle k="347.8124275032088" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="347.8124275032088" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="518.1453180402467" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="351.2838318621207" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="351.2838318621207" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="342.76504781043224" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
+<Angle k="342.76504781043224" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
+<Angle k="626.926409534505" angle="2.0243821725347937" class1="13" class2="14" class3="15"/>
+<Angle k="332.6108743250879" angle="2.089150994980823" class1="13" class2="14" class3="21"/>
+<Angle k="360.32975289882074" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
+<Angle k="360.32975289882074" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
+<Angle k="510.42926697989026" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
+<Angle k="360.32975289882074" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
+<Angle k="360.32975289882074" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
+<Angle k="615.2532057010558" angle="2.0995148997924606" class1="14" class2="21" class3="18"/>
+<Angle k="332.6108743250879" angle="2.089150994980823" class1="15" class2="14" class3="21"/>
+<Angle k="613.520572707836" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="343.83053990492874" angle="1.909277539646191" class1="15" class2="16" class3="31"/>
+<Angle k="343.83053990492874" angle="1.909277539646191" class1="15" class2="16" class3="32"/>
+<Angle k="357.59809010841917" angle="1.9232796805236196" class1="16" class2="15" class3="29"/>
+<Angle k="357.59809010841917" angle="1.9232796805236196" class1="16" class2="15" class3="30"/>
+<Angle k="372.0118393844262" angle="1.943315971326614" class1="16" class2="17" class3="18"/>
+<Angle k="352.91171423113997" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="352.91171423113997" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="361.6020494110675" angle="1.9292385966058516" class1="17" class2="16" class3="31"/>
+<Angle k="361.6020494110675" angle="1.9292385966058516" class1="17" class2="16" class3="32"/>
+<Angle k="540.500703892533" angle="2.0920714568393497" class1="17" class2="18" class3="19"/>
+<Angle k="415.0389862270244" angle="2.103919470297239" class1="17" class2="18" class3="21"/>
+<Angle k="299.12261755376636" angle="1.9130853729463788" class1="18" class2="17" class3="33"/>
+<Angle k="299.12261755376636" angle="1.9130853729463788" class1="18" class2="17" class3="34"/>
+<Angle k="219.81426916169406" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="325.06707433401453" angle="2.063353684711203" class1="18" class2="19" class3="35"/>
+<Angle k="371.8912055523152" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="190.35707302279764" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="261.80733620473706" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
+<Angle k="270.0576346376337" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="260.05582174920033" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
+<Angle k="260.05582174920033" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
+<Angle k="266.4643670367114" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="273.06353356212253" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce>
+<UreyBradley k="32909.043845090455" d="0.2165296767511864" class1="0" class2="1" class3="2"/>
+<UreyBradley k="32909.043845090455" d="0.2165296767511864" class1="0" class2="1" class3="3"/>
+<UreyBradley k="17338.462349984657" d="0.2367308754593913" class1="0" class2="1" class3="4"/>
+<UreyBradley k="11336.53280183118" d="0.24637183735463966" class1="1" class2="4" class3="5"/>
+<UreyBradley k="16518.925085759667" d="0.25524846938426365" class1="1" class2="4" class3="20"/>
+<UreyBradley k="32909.043845090455" d="0.2165296767511864" class1="2" class2="1" class3="3"/>
+<UreyBradley k="17338.462349984657" d="0.2367308754593913" class1="2" class2="1" class3="4"/>
+<UreyBradley k="17338.462349984657" d="0.2367308754593913" class1="3" class2="1" class3="4"/>
+<UreyBradley k="16721.59123795196" d="0.24424950724834096" class1="4" class2="5" class3="6"/>
+<UreyBradley k="7123.740132045221" d="0.2137728474468069" class1="4" class2="5" class3="22"/>
+<UreyBradley k="14612.905935614828" d="0.24235320460628296" class1="4" class2="20" class3="9"/>
+<UreyBradley k="19025.08826210634" d="0.25380961300478017" class1="4" class2="20" class3="19"/>
+<UreyBradley k="24467.446866284412" d="0.24317848563613784" class1="5" class2="4" class3="20"/>
+<UreyBradley k="31263.83095752329" d="0.23691569131052767" class1="5" class2="6" class3="7"/>
+<UreyBradley k="17756.276712617444" d="0.24040627753085944" class1="5" class2="6" class3="8"/>
+<UreyBradley k="8416.384305965848" d="0.2161692161213254" class1="6" class2="5" class3="22"/>
+<UreyBradley k="21763.00718147895" d="0.24155207989996136" class1="6" class2="8" class3="9"/>
+<UreyBradley k="47414.41417267965" d="0.22173066563125332" class1="7" class2="6" class3="8"/>
+<UreyBradley k="28805.441787722477" d="0.23348443062234245" class1="8" class2="9" class3="10"/>
+<UreyBradley k="16553.114211451757" d="0.24099962566280914" class1="8" class2="9" class3="20"/>
+<UreyBradley k="9739.284134489099" d="0.25086157621033756" class1="9" class2="10" class3="11"/>
+<UreyBradley k="24639.371216609514" d="0.24036036623340684" class1="9" class2="10" class3="21"/>
+<UreyBradley k="22288.129278420707" d="0.23893622663484196" class1="9" class2="20" class3="19"/>
+<UreyBradley k="19825.919649197967" d="0.24561151969819403" class1="10" class2="9" class3="20"/>
+<UreyBradley k="10178.726758904737" d="0.2504351766819783" class1="10" class2="11" class3="12"/>
+<UreyBradley k="8753.362487010529" d="0.2143215696888813" class1="10" class2="11" class3="23"/>
+<UreyBradley k="8753.362487010529" d="0.2143215696888813" class1="10" class2="11" class3="24"/>
+<UreyBradley k="23590.24606193989" d="0.2419133662967915" class1="10" class2="21" class3="14"/>
+<UreyBradley k="20921.333131428408" d="0.24493117218016575" class1="10" class2="21" class3="18"/>
+<UreyBradley k="7554.680816264936" d="0.2554238649411517" class1="11" class2="10" class3="21"/>
+<UreyBradley k="15549.019045091822" d="0.24943515144206754" class1="11" class2="12" class3="13"/>
+<UreyBradley k="5749.814974867141" d="0.21638649819857228" class1="11" class2="12" class3="25"/>
+<UreyBradley k="5749.814974867141" d="0.21638649819857228" class1="11" class2="12" class3="26"/>
+<UreyBradley k="5943.013157098885" d="0.2163769876060223" class1="12" class2="11" class3="23"/>
+<UreyBradley k="5943.013157098885" d="0.2163769876060223" class1="12" class2="11" class3="24"/>
+<UreyBradley k="16359.359831529755" d="0.2445664336412628" class1="12" class2="13" class3="14"/>
+<UreyBradley k="5763.249563372211" d="0.21627463620927637" class1="12" class2="13" class3="27"/>
+<UreyBradley k="5763.249563372211" d="0.21627463620927637" class1="12" class2="13" class3="28"/>
+<UreyBradley k="6735.472707394489" d="0.21469257349759774" class1="13" class2="12" class3="25"/>
+<UreyBradley k="6735.472707394489" d="0.21469257349759774" class1="13" class2="12" class3="26"/>
+<UreyBradley k="1802.6793125152797" d="0.24660181294705075" class1="13" class2="14" class3="15"/>
+<UreyBradley k="12698.167267773295" d="0.24530456727951677" class1="13" class2="14" class3="21"/>
+<UreyBradley k="11473.560440360467" d="0.20904668083340297" class1="14" class2="13" class3="27"/>
+<UreyBradley k="11473.560440360467" d="0.20904668083340297" class1="14" class2="13" class3="28"/>
+<UreyBradley k="16373.103028501915" d="0.245062869216797" class1="14" class2="15" class3="16"/>
+<UreyBradley k="11473.560440360467" d="0.20904668083340297" class1="14" class2="15" class3="29"/>
+<UreyBradley k="11473.560440360467" d="0.20904668083340297" class1="14" class2="15" class3="30"/>
+<UreyBradley k="22866.260096577684" d="0.24341685186846435" class1="14" class2="21" class3="18"/>
+<UreyBradley k="12698.167267773295" d="0.24530456727951677" class1="15" class2="14" class3="21"/>
+<UreyBradley k="15083.43588500777" d="0.2482899688867673" class1="15" class2="16" class3="17"/>
+<UreyBradley k="6866.002563455009" d="0.21482896649717576" class1="15" class2="16" class3="31"/>
+<UreyBradley k="6866.002563455009" d="0.21482896649717576" class1="15" class2="16" class3="32"/>
+<UreyBradley k="5356.542667156585" d="0.21612101918688453" class1="16" class2="15" class3="29"/>
+<UreyBradley k="5356.542667156585" d="0.21612101918688453" class1="16" class2="15" class3="30"/>
+<UreyBradley k="10383.926268907446" d="0.25071186281720664" class1="16" class2="17" class3="18"/>
+<UreyBradley k="6214.400575476635" d="0.21588768954068122" class1="16" class2="17" class3="33"/>
+<UreyBradley k="6214.400575476635" d="0.21588768954068122" class1="16" class2="17" class3="34"/>
+<UreyBradley k="5892.2131595419705" d="0.2166014429827969" class1="17" class2="16" class3="31"/>
+<UreyBradley k="5892.2131595419705" d="0.2166014429827969" class1="17" class2="16" class3="32"/>
+<UreyBradley k="6790.07850550407" d="0.2501622513015906" class1="17" class2="18" class3="19"/>
+<UreyBradley k="8313.142957460728" d="0.25504206857818595" class1="17" class2="18" class3="21"/>
+<UreyBradley k="7472.6490112415395" d="0.2145767289449851" class1="18" class2="17" class3="33"/>
+<UreyBradley k="7472.6490112415395" d="0.2145767289449851" class1="18" class2="17" class3="34"/>
+<UreyBradley k="26063.29704486729" d="0.24352193235081804" class1="18" class2="19" class3="20"/>
+<UreyBradley k="3998.690167807186" d="0.21177124922411472" class1="18" class2="19" class3="35"/>
+<UreyBradley k="26350.207094799764" d="0.24207073997933107" class1="19" class2="18" class3="21"/>
+<UreyBradley k="5324.194823224806" d="0.21560948327565438" class1="20" class2="19" class3="35"/>
+<UreyBradley k="6866.930252583605" d="0.17462080461979723" class1="23" class2="11" class3="24"/>
+<UreyBradley k="6714.957228957867" d="0.1766165058419895" class1="25" class2="12" class3="26"/>
+<UreyBradley k="6591.853252119447" d="0.17685797959042412" class1="27" class2="13" class3="28"/>
+<UreyBradley k="6591.853252119447" d="0.17685797959042412" class1="29" class2="15" class3="30"/>
+<UreyBradley k="6632.385295181313" d="0.1767871797367549" class1="31" class2="16" class3="32"/>
+<UreyBradley k="6891.229077996574" d="0.17560269028929812" class1="33" class2="17" class3="34"/>
+</AmoebaUreyBradleyForce>
 <PeriodicTorsionForce ordering="charmm">
-<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="15.473463227808722" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="24.563640891914183" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="13.954774388128113" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="1.090815379803e-06" k2="-1.820904031448" k3="-1.397602068345" k4="1.048805198527e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="9.573767654631e-07" k2="9.712280146003e-07" k3="-0.9391040431309" k4="1.047922684022e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="62.76603413970627" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="43.133777465195095" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="13.974735215324651" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="32.18167917496398" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="20.07872661956894" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="6.104857592585052" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="21.553695299112583" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="7.522756764653054" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="10.980117363726146" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="19.686367153974892" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="35.83233697287645" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="13.21799676515167" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="19.855561721123287" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="27.04023902529637" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="19.986760642803024" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="13.319307598582146" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="19.378021510853664" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="21.94926717207507" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="10.788588345160615" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="5.078542475508571" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="6.143392431427742" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="37.75627559250844" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="36.41427607021837" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="25.634665243843635" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="17.570887319483386" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="26.671876584664247" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="4.546919066371498" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="22.783833553150686" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="21.61765933035253" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="2.824280464463056" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="23.05852443664049" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="20.226958971463848" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="21.660701605400497" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="3.5740794609122" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="28.80048878534939" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="15.459903862127184" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="2.2633223533411643e-33" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="1.48842090464541e-13" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="5.668348467162156e-53" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="24.54033124115337" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="13.95541248154935" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="21.55415749763718" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="7.5150833781645625" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="62.768382804058284" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="43.13284362265937" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="35.834649195287625" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="19.849222784049317" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="10.977824080087283" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="13.210910387803827" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.693941182602646" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="5.104401498838107e-18" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="27.057507372563073" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="19.998732200309515" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="25.669613018671367" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="21.6612689216842" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="13.968788438438958" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="13.30297307339146" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="32.183044588539545" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="5.083751013702751" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="4.600195102114017" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="19.354679982398885" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="1.0509738482436128e-44" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="17.502805336213893" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="26.662140059974167" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="6.195700500150762" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="10"/>
+<Proper k1="0" k2="2.875336102121844" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="1.362760854980599e-28" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0" k2="23.107491789596757" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="20.238861101307965" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="3.587026991614384" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="28.811530719559677" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="37.77292442351982" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="22.756424127644223" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="36.41225934784255" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="21.626596400089024" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="20.07230643372853" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="21.93770969470604" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="9"/>
+<Proper k1="0" k2="6.097053668838813" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="10.77790240173767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="9"/>
+<Proper k1="1.053979380361e-06" k2="-1.82090381357" k3="-1.260983995482" k4="1.508633583836e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="9.927703376697e-07" k2="7.318569520306e-07" k3="-0.9391041326783" k4="1.599170629989e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="1.053979380361e-06" k2="-1.82090381357" k3="-1.260983995482" k4="1.508633583836e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="9.927703376697e-07" k2="7.318569520306e-07" k3="-0.9391041326783" k4="1.599170629989e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="1.053979380361e-06" k2="-1.82090381357" k3="-1.260983995482" k4="1.508633583836e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="9.927703376697e-07" k2="7.318569520306e-07" k3="-0.9391041326783" k4="1.599170629989e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
 </PeriodicTorsionForce>
 <RBTorsionForce>
-<Proper c0="19.515" c1="56.0" c2="40.173" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
-<Proper c0="21.431" c1="83.552" c2="81.435" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
-<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
-<Proper c0="20.886" c1="80.774" c2="78.098" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
-<Proper c0="17.459" c1="54.14" c2="41.972" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
-<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
+<Proper c0="19.411" c1="55.701" c2="39.959" c3="0" c4="0" c5="0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.51" c1="83.862" c2="81.737" c3="0" c4="0" c5="0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0" c4="0" c5="0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0" c4="0" c5="0" class1="21" class2="14" class3="15" class4="16"/>
+<Proper c0="20.966" c1="81.085" c2="78.398" c3="0" c4="0" c5="0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="17.426" c1="54.036" c2="41.891" c3="0" c4="0" c5="0" class1="15" class2="16" class3="17" class4="18"/>
 </RBTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
-<Atom charge="-0.25233" epsilon="0.26146577464789816" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_0"/>
 <Atom charge="0.776573" epsilon="0.2732087688406762" sigma="0.3089811804362698" type="QUBE_1"/>
-<Atom charge="-0.242744" epsilon="0.2601425350261072" sigma="0.29666886791766617" type="QUBE_2"/>
-<Atom charge="-0.251133" epsilon="0.2614064687902009" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_2"/>
+<Atom charge="-0.248736" epsilon="0.2610059517775959" sigma="0.29746875607798895" type="QUBE_3"/>
 <Atom charge="-0.051181" epsilon="0.3114224736729138" sigma="0.34366343352476914" type="QUBE_4"/>
 <Atom charge="-0.303105" epsilon="0.32369222426161337" sigma="0.3546262114386765" type="QUBE_5"/>
 <Atom charge="0.667684" epsilon="0.273086823211064" sigma="0.3088691064321672" type="QUBE_6"/>
-<Atom charge="-0.56416" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
+<Atom charge="-0.564160" epsilon="0.7357755522008077" sigma="0.2893770395629382" type="QUBE_7"/>
 <Atom charge="-0.266561" epsilon="0.6874490135799819" sigma="0.27383444348429714" type="QUBE_8"/>
 <Atom charge="0.227775" epsilon="0.2970905744228003" sigma="0.33075499678354847" type="QUBE_9"/>
 <Atom charge="-0.120378" epsilon="0.3152955026616835" sigma="0.34713250572596427" type="QUBE_10"/>
@@ -458,18 +393,18 @@
 <Atom charge="-0.078422" epsilon="0.3156767824810448" sigma="0.3474735849213942" type="QUBE_20"/>
 <Atom charge="0.155012" epsilon="0.30132283520205017" sigma="0.3345788062188248" type="QUBE_21"/>
 <Atom charge="0.167521" epsilon="0.0978107710473215" sigma="0.23811289791476886" type="QUBE_22"/>
-<Atom charge="0.097355" epsilon="0.10056024578458915" sigma="0.24353785483009005" type="QUBE_23"/>
-<Atom charge="0.090775" epsilon="0.1012671279779549" sigma="0.24492807935732094" type="QUBE_24"/>
-<Atom charge="0.091394" epsilon="0.10002118610996971" sigma="0.24247645596416315" type="QUBE_25"/>
-<Atom charge="0.095147" epsilon="0.09768974390991514" sigma="0.2378734492279842" type="QUBE_26"/>
-<Atom charge="0.078988" epsilon="0.10050647116630629" sigma="0.24343202152984458" type="QUBE_27"/>
-<Atom charge="0.061498" epsilon="0.10369430117364004" sigma="0.24968785757653836" type="QUBE_28"/>
-<Atom charge="0.079282" epsilon="0.10037122656954406" sigma="0.24316580104266824" type="QUBE_29"/>
-<Atom charge="0.06061" epsilon="0.1036603620040513" sigma="0.2496214465559107" type="QUBE_30"/>
-<Atom charge="0.093159" epsilon="0.1001076810033671" sigma="0.24264683492102518" type="QUBE_31"/>
-<Atom charge="0.096345" epsilon="0.09777800648277413" sigma="0.23804807965605482" type="QUBE_32"/>
-<Atom charge="0.096629" epsilon="0.09882519092751813" sigma="0.24011772344082505" type="QUBE_33"/>
-<Atom charge="0.087509" epsilon="0.1010563421031184" sigma="0.24451371781920664" type="QUBE_34"/>
-<Atom charge="0.113031" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
+<Atom charge="0.094065" epsilon="0.10091457682034005" sigma="0.24423494543901622" type="QUBE_23"/>
+<Atom charge="0.094065" epsilon="0.10091457682034005" sigma="0.24423494543901622" type="QUBE_24"/>
+<Atom charge="0.093270" epsilon="0.09886534679264636" sigma="0.24019700498485672" type="QUBE_25"/>
+<Atom charge="0.093270" epsilon="0.09886534679264636" sigma="0.24019700498485672" type="QUBE_26"/>
+<Atom charge="0.070243" epsilon="0.10211827266242138" sigma="0.24659961468037703" type="QUBE_27"/>
+<Atom charge="0.070243" epsilon="0.10211827266242138" sigma="0.24659961468037703" type="QUBE_28"/>
+<Atom charge="0.069946" epsilon="0.10203485128906832" sigma="0.2464359018909392" type="QUBE_29"/>
+<Atom charge="0.069946" epsilon="0.10203485128906832" sigma="0.2464359018909392" type="QUBE_30"/>
+<Atom charge="0.094752" epsilon="0.09895270183569954" sigma="0.2403694531678513" type="QUBE_31"/>
+<Atom charge="0.094752" epsilon="0.09895270183569954" sigma="0.2403694531678513" type="QUBE_32"/>
+<Atom charge="0.092069" epsilon="0.09994971821223084" sigma="0.2423356565804284" type="QUBE_33"/>
+<Atom charge="0.092069" epsilon="0.09994971821223084" sigma="0.2423356565804284" type="QUBE_34"/>
+<Atom charge="0.113033" epsilon="0.10362675476918622" sigma="0.2495556810389295" type="QUBE_35"/>
 </NonbondedForce>
 </ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-modsem-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-modsem-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -125,9 +125,9 @@
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13496011742992933" k="259586.48572299856" class1="0" class2="1"/>
-<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="2"/>
-<Bond length="0.13456028739667647" k="265410.28124514845" class1="1" class2="3"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="0" class2="1"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="1" class2="2"/>
+<Bond length="0.13469356407442742" k="263469.0160710985" class1="1" class2="3"/>
 <Bond length="0.15089307265750462" k="205802.9322041371" class1="1" class2="4"/>
 <Bond length="0.13479954466568161" k="460185.44749956" class1="4" class2="5"/>
 <Bond length="0.14424155029894592" k="249691.30512503046" class1="4" class2="20"/>
@@ -168,230 +168,231 @@
 <HarmonicAngleForce>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
-<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
-<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
-<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
 <Angle k="808.8627774996936" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
+<Angle k="849.9711499843376" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
 <Angle k="849.9711499843376" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
 <Angle k="849.9711499843376" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
+<Angle k="607.1521925095469" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="547.3711663565517" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
 <Angle k="639.7476858128786" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
 <Angle k="262.3563023615395" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
-<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
-<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
-<Angle k="623.9958170254897" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
 <Angle k="557.4746848468715" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
 <Angle k="807.9095983882028" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
-<Angle k="251.30017554046" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
-<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
 <Angle k="552.9254852453236" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="1493.2380322110268" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
 <Angle k="751.8116762302967" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
 <Angle k="718.830040433039" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
+<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
 <Angle k="553.7538746695924" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
 <Angle k="648.9592299042741" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
-<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
-<Angle k="873.171217244757" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
+<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
 <Angle k="1121.6908591863469" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
 <Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
 <Angle k="375.49500093231916" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
-<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
-<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
-<Angle k="600.2681337330977" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
 <Angle k="795.9032365496385" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
 <Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
 <Angle k="437.24469346052615" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
-<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
-<Angle k="484.11021017276164" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
+<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
+<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
 <Angle k="1061.3339489822274" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
 <Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
 <Angle k="505.6323293521324" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
-<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="25"/>
-<Angle k="508.70941574656774" angle="1.9077297675423204" class1="13" class2="12" class3="26"/>
-<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
-<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
 <Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="27"/>
 <Angle k="463.12966287707894" angle="1.90461735439072" class1="14" class2="13" class3="28"/>
+<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
+<Angle k="729.7291356328897" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
+<Angle k="663.876383192078" angle="2.0815335204983105" class1="13" class2="14" class3="21"/>
+<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
 <Angle k="1043.2371059142824" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
 <Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="29"/>
 <Angle k="456.4386871639268" angle="1.905010598615325" class1="14" class2="15" class3="30"/>
-<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
-<Angle k="673.5597443194678" angle="2.0967684694633366" class1="15" class2="14" class3="21"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
+<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
 <Angle k="1017.6871864118357" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
 <Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
 <Angle k="509.19412696662016" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
-<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
-<Angle k="519.6363870107552" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
+<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
+<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
 <Angle k="1173.139818868356" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
 <Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
 <Angle k="429.8833786918116" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
-<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
-<Angle k="396.92426943598116" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
-<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
-<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
 <Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
 <Angle k="444.4379801772719" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
+<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="669.1194725767053" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
+<Angle k="626.1834322747222" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
+<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
 <Angle k="700.965705603468" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
 <Angle k="282.6287693615428" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
-<Angle k="784.166896582325" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
 <Angle k="264.5571241818087" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
-<Angle k="280.27209171282095" angle="1.8439447146876222" class1="23" class2="11" class3="24"/>
-<Angle k="313.9874014254898" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
-<Angle k="337.30586690652257" angle="1.8708859037134735" class1="27" class2="13" class3="28"/>
-<Angle k="330.4448321172715" angle="1.8688841161041359" class1="29" class2="15" class3="30"/>
-<Angle k="305.84747196069804" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
-<Angle k="304.0019708681262" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="747.2647320294791" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
+<Angle k="784.8233051504028" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="796.8784812186918" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="764.458725809869" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
+<Angle k="1030.9686012055336" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
+<Angle k="769.7656901007015" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce/>
 <PeriodicTorsionForce ordering="smirnoff">
-<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="7.023541426947e-07" k2="-1.820904013376" k3="-0.8597878878206" k4="9.576517074274e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="9.075704546271e-07" k2="9.337413443292e-07" k3="-0.5561331051145" k4="1.034742310192e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="4.387824313701576" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="8.73309354582912" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="4.5638573257493125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="3.963481805801758" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
-<Proper k1="0" k2="0" k3="0.35206522854808026" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="1.553766914856793" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="21.767750609806672" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
-<Proper k1="0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="-0.93912285044788" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
-<Proper k1="0" k2="15.644812519052767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
-<Proper k1="0" k2="0" k3="0.8390569818512192" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
-<Improper k1="0" k2="14.644" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
-<Improper k1="0" k2="1.3946666666666667" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
-<Improper k1="0" k2="1.5341333333333336" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
+<Proper k1="8.182821138572e-07" k2="-1.82090416464" k3="-0.8597941986874" k4="1.32153104162e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="7.841190895946e-07" k2="1.100577147082e-06" k3="-0.5561264662879" k4="1.365642912173e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="8.182821138572e-07" k2="-1.82090416464" k3="-0.8597941986874" k4="1.32153104162e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="7.841190895946e-07" k2="1.100577147082e-06" k3="-0.5561264662879" k4="1.365642912173e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="8.182821138572e-07" k2="-1.82090416464" k3="-0.8597941986874" k4="1.32153104162e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="7.841190895946e-07" k2="1.100577147082e-06" k3="-0.5561264662879" k4="1.365642912173e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
+<Proper k1="0.0" k2="1.6652398534031456" k3="-1.6479186921189017" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0.0" k2="4.387824313701576" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="4" class4="20"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="8.73309354582912" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0.0" k2="4.5638573257493125" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="12"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="13"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="15"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="14"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="11" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="15"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="12" class2="13" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="12" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="16"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="17"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="3.963481805801758" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="18"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="15" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="16" class2="15" class3="14" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="19"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.0" k3="0.35206522854808026" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="16" class3="15" class4="30"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="1.553766914856793" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="21.767750609806672" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="23"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="24"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="29"/>
+<Proper k1="0.0" k2="0.7802448648863632" k3="-0.19137745034585105" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="15" class4="30"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="-0.93912285044788" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="17" class4="34"/>
+<Proper k1="0.0" k2="15.644812519052767" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="23" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="25"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="24" class2="11" class3="12" class4="26"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="25" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="27"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="26" class2="12" class3="13" class4="28"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="29" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="31"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="30" class2="15" class3="16" class4="32"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="31" class2="16" class3="17" class4="34"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="33"/>
+<Proper k1="0.0" k2="0.0" k3="0.8390569818512192" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="32" class2="16" class3="17" class4="34"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="20" class3="1" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="1" class3="5" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="4" class2="5" class3="20" class4="1"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="22" class3="4" class4="6"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="4" class3="6" class4="22"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="5" class2="6" class3="22" class4="4"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="8" class3="5" class4="7"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="5" class3="7" class4="8"/>
+<Improper k1="0.0" k2="14.644" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="6" class2="7" class3="8" class4="5"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="20" class3="8" class4="10"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="8" class3="10" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="9" class2="10" class3="20" class4="8"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="21" class3="9" class4="11"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="9" class3="11" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="10" class2="11" class3="21" class4="9"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="21" class3="13" class4="15"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="13" class3="15" class4="21"/>
+<Improper k1="0.0" k2="1.3946666666666667" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="14" class2="15" class3="21" class4="13"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="21" class3="17" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="17" class3="19" class4="21"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="18" class2="19" class3="21" class4="17"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="35" class3="18" class4="20"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="18" class3="20" class4="35"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="19" class2="20" class3="35" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="19" class3="4" class4="9"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="4" class3="9" class4="19"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="20" class2="9" class3="19" class4="4"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="18" class3="10" class4="14"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="10" class3="14" class4="18"/>
+<Improper k1="0.0" k2="1.5341333333333336" k3="0.0" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="21" class2="14" class3="18" class4="10"/>
 </PeriodicTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
-<Atom charge="-0.25233" epsilon="0.24312107096883973" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_0"/>
 <Atom charge="0.776573" epsilon="0.3137621288766835" sigma="0.29731865548843023" type="QUBE_1"/>
-<Atom charge="-0.242744" epsilon="0.24178358454706314" sigma="0.29666886791766617" type="QUBE_2"/>
-<Atom charge="-0.251133" epsilon="0.24306111392023294" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_2"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_3"/>
 <Atom charge="-0.051181" epsilon="0.3617577618615011" sigma="0.33069182353388327" type="QUBE_4"/>
 <Atom charge="-0.303105" epsilon="0.3772809207194576" sigma="0.34124081032064807" type="QUBE_5"/>
 <Atom charge="0.667684" epsilon="0.313609862900308" sigma="0.2972108117286001" type="QUBE_6"/>
-<Atom charge="-0.56416" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
-<Atom charge="-0.158328" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
+<Atom charge="-0.564160" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
+<Atom charge="-0.158383" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
 <Atom charge="0.227775" epsilon="0.3436932883429018" sigma="0.318270617002993" type="QUBE_9"/>
 <Atom charge="-0.120378" epsilon="0.36665208454511444" sigma="0.3340299552647392" type="QUBE_10"/>
 <Atom charge="-0.150389" epsilon="0.36713490953834793" sigma="0.3343586499521666" type="QUBE_11"/>
@@ -406,20 +407,20 @@
 <Atom charge="-0.078422" epsilon="0.36713419029681693" sigma="0.33435816039249844" type="QUBE_20"/>
 <Atom charge="0.155012" epsilon="0.34902004099725037" sigma="0.3219500963762515" type="QUBE_21"/>
 <Atom charge="0.167521" epsilon="0.08327170335092592" sigma="0.24047595644632233" type="QUBE_22"/>
-<Atom charge="0.097355" epsilon="0.08581986873989693" sigma="0.24595475122945462" type="QUBE_23"/>
-<Atom charge="0.090775" epsilon="0.08647598481424516" sigma="0.2473587724974695" type="QUBE_24"/>
-<Atom charge="0.091394" epsilon="0.08531979298529052" sigma="0.24488281892469482" type="QUBE_25"/>
-<Atom charge="0.095147" epsilon="0.08315967981655392" sigma="0.24023413144449074" type="QUBE_26"/>
-<Atom charge="0.078988" epsilon="0.08576997248810035" sigma="0.24584786762792243" type="QUBE_27"/>
-<Atom charge="0.061498" epsilon="0.08873187374227504" sigma="0.2521657872781152" type="QUBE_28"/>
-<Atom charge="0.079282" epsilon="0.08564449238725468" sigma="0.24557900513941391" type="QUBE_29"/>
-<Atom charge="0.06061" epsilon="0.08870029760695072" sigma="0.2520987171872303" type="QUBE_30"/>
-<Atom charge="0.093159" epsilon="0.08540001689934773" sigma="0.24505488874102366" type="QUBE_31"/>
-<Atom charge="0.096345" epsilon="0.08324137505423658" sigma="0.24041049492409503" type="QUBE_32"/>
-<Atom charge="0.096629" epsilon="0.08421113158571183" sigma="0.2425006780809266" type="QUBE_33"/>
-<Atom charge="0.087509" epsilon="0.08628029498385563" sigma="0.24694029878997514" type="QUBE_34"/>
-<Atom charge="0.113032" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
-<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site1"/>
-<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site2"/>
+<Atom charge="0.094065" epsilon="0.08614870266486319" sigma="0.24665875984208874" type="QUBE_23"/>
+<Atom charge="0.094065" epsilon="0.08614870266486319" sigma="0.24665875984208874" type="QUBE_24"/>
+<Atom charge="0.093270" epsilon="0.0842483362791437" sigma="0.2425807464237023" type="QUBE_25"/>
+<Atom charge="0.093270" epsilon="0.0842483362791437" sigma="0.2425807464237023" type="QUBE_26"/>
+<Atom charge="0.070243" epsilon="0.08726653322185535" sigma="0.24904689632052085" type="QUBE_27"/>
+<Atom charge="0.070243" epsilon="0.08726653322185535" sigma="0.24904689632052085" type="QUBE_28"/>
+<Atom charge="0.069946" epsilon="0.08718902543869833" sigma="0.24888155882739335" type="QUBE_29"/>
+<Atom charge="0.069946" epsilon="0.08718902543869833" sigma="0.24888155882739335" type="QUBE_30"/>
+<Atom charge="0.094752" epsilon="0.084329275899709" sigma="0.242754906001391" type="QUBE_31"/>
+<Atom charge="0.094752" epsilon="0.084329275899709" sigma="0.242754906001391" type="QUBE_32"/>
+<Atom charge="0.092069" epsilon="0.08525351116022171" sigma="0.2447406222324233" type="QUBE_33"/>
+<Atom charge="0.092069" epsilon="0.08525351116022171" sigma="0.2447406222324233" type="QUBE_34"/>
+<Atom charge="0.113033" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
+<Atom charge="-0.054089" epsilon="0" sigma="1" type="v-site1"/>
+<Atom charge="-0.054089" epsilon="0" sigma="1" type="v-site2"/>
 </NonbondedForce>
 </ForceField>

--- a/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-qcforce-ub-rfree.xml
+++ b/force_fields/ground/cam-b3lyp-refit-rfree/coumarin-sites-qcforce-ub-rfree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ForceField>
-<QUBEKit Version="2.1.1" Date="2022_03_04"/>
+<QUBEKit Version="2.1.1+28.gfab9742.dirty" Date="2022_10_12"/>
 <AtomTypes>
 <Type name="QUBE_0" class="0" element="F" mass="18.998"/>
 <Type name="QUBE_1" class="1" element="C" mass="12.011"/>
@@ -120,336 +120,271 @@
 <Bond from="18" to="21"/>
 <Bond from="19" to="20"/>
 <Bond from="19" to="35"/>
-<Bond from="0" to="2"/>
-<Bond from="0" to="3"/>
-<Bond from="0" to="4"/>
-<Bond from="1" to="5"/>
-<Bond from="1" to="20"/>
-<Bond from="2" to="3"/>
-<Bond from="2" to="4"/>
-<Bond from="3" to="4"/>
-<Bond from="4" to="6"/>
-<Bond from="4" to="22"/>
-<Bond from="4" to="9"/>
-<Bond from="4" to="19"/>
-<Bond from="5" to="20"/>
-<Bond from="5" to="7"/>
-<Bond from="5" to="8"/>
-<Bond from="6" to="22"/>
-<Bond from="6" to="9"/>
-<Bond from="7" to="8"/>
-<Bond from="8" to="10"/>
-<Bond from="8" to="20"/>
-<Bond from="9" to="11"/>
-<Bond from="9" to="21"/>
-<Bond from="9" to="19"/>
-<Bond from="10" to="20"/>
-<Bond from="10" to="12"/>
-<Bond from="10" to="23"/>
-<Bond from="10" to="24"/>
-<Bond from="10" to="14"/>
-<Bond from="10" to="18"/>
-<Bond from="11" to="21"/>
-<Bond from="11" to="13"/>
-<Bond from="11" to="25"/>
-<Bond from="11" to="26"/>
-<Bond from="12" to="23"/>
-<Bond from="12" to="24"/>
-<Bond from="12" to="14"/>
-<Bond from="12" to="27"/>
-<Bond from="12" to="28"/>
-<Bond from="13" to="25"/>
-<Bond from="13" to="26"/>
-<Bond from="13" to="15"/>
-<Bond from="13" to="21"/>
-<Bond from="14" to="27"/>
-<Bond from="14" to="28"/>
-<Bond from="14" to="16"/>
-<Bond from="14" to="29"/>
-<Bond from="14" to="30"/>
-<Bond from="14" to="18"/>
-<Bond from="15" to="21"/>
-<Bond from="15" to="17"/>
-<Bond from="15" to="31"/>
-<Bond from="15" to="32"/>
-<Bond from="16" to="29"/>
-<Bond from="16" to="30"/>
-<Bond from="16" to="18"/>
-<Bond from="16" to="33"/>
-<Bond from="16" to="34"/>
-<Bond from="17" to="31"/>
-<Bond from="17" to="32"/>
-<Bond from="17" to="19"/>
-<Bond from="17" to="21"/>
-<Bond from="18" to="33"/>
-<Bond from="18" to="34"/>
-<Bond from="18" to="20"/>
-<Bond from="18" to="35"/>
-<Bond from="19" to="21"/>
-<Bond from="20" to="35"/>
-<Bond from="23" to="24"/>
-<Bond from="25" to="26"/>
-<Bond from="27" to="28"/>
-<Bond from="29" to="30"/>
-<Bond from="31" to="32"/>
-<Bond from="33" to="34"/>
 <VirtualSite p1="-0.0307" p2="-0.0566" p3="0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="36"/>
 <VirtualSite p1="-0.0307" p2="-0.0566" p3="-0.0644" atom1="8" atom2="6" atom3="9" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0" index="37"/>
 </Residue>
 </Residues>
 <HarmonicBondForce>
-<Bond length="0.13469356407442745" k="248710.72048826894" class1="0" class2="1"/>
-<Bond length="0.13469356407442745" k="248710.72048826894" class1="1" class2="2"/>
-<Bond length="0.13469356407442745" k="248710.72048826894" class1="1" class2="3"/>
-<Bond length="0.15089307265750462" k="218125.2973797079" class1="1" class2="4"/>
-<Bond length="0.13479954466568161" k="452537.0120235957" class1="4" class2="5"/>
-<Bond length="0.14424155029894592" k="235785.886002724" class1="4" class2="20"/>
-<Bond length="0.14564591082883707" k="214126.92128785737" class1="5" class2="6"/>
-<Bond length="0.10814511275621548" k="337583.37226720486" class1="5" class2="22"/>
-<Bond length="0.12065331189134901" k="697181.8374609897" class1="6" class2="7"/>
-<Bond length="0.13738032210105275" k="170764.06572729698" class1="6" class2="8"/>
-<Bond length="0.13688031490221975" k="246190.18785439065" class1="8" class2="9"/>
-<Bond length="0.13896874772055995" k="302717.2225235032" class1="9" class2="10"/>
-<Bond length="0.14002870254626093" k="278746.28794164985" class1="9" class2="20"/>
-<Bond length="0.15105020854333961" k="198333.8619132481" class1="10" class2="11"/>
-<Bond length="0.14097123172598094" k="267347.65667859913" class1="10" class2="21"/>
-<Bond length="0.15240838998674713" k="188827.0108461436" class1="11" class2="12"/>
-<Bond length="0.10957700046070398" k="298264.66152674344" class1="11" class2="23"/>
-<Bond length="0.10957700046070398" k="298264.66152674344" class1="11" class2="24"/>
-<Bond length="0.15195279246806304" k="191034.5384730615" class1="12" class2="13"/>
-<Bond length="0.1095362671842942" k="299524.17045776814" class1="12" class2="25"/>
-<Bond length="0.1095362671842942" k="299524.17045776814" class1="12" class2="26"/>
-<Bond length="0.14540284161875516" k="204810.5084630868" class1="13" class2="14"/>
-<Bond length="0.10990907747815233" k="289936.61477030907" class1="13" class2="27"/>
-<Bond length="0.10990907747815233" k="289936.61477030907" class1="13" class2="28"/>
-<Bond length="0.14540284161875516" k="204810.5084630868" class1="14" class2="15"/>
-<Bond length="0.1382504797109479" k="275225.2410849799" class1="14" class2="21"/>
-<Bond length="0.15197197918433358" k="190718.45269290742" class1="15" class2="16"/>
-<Bond length="0.10990907747815233" k="289936.61477030907" class1="15" class2="29"/>
-<Bond length="0.10990907747815233" k="289936.61477030907" class1="15" class2="30"/>
-<Bond length="0.15233937621320012" k="188429.22378711312" class1="16" class2="17"/>
-<Bond length="0.10954484075537119" k="299171.8758940889" class1="16" class2="31"/>
-<Bond length="0.10954484075537119" k="299171.8758940889" class1="16" class2="32"/>
-<Bond length="0.15125045314560479" k="200860.66147330133" class1="17" class2="18"/>
-<Bond length="0.10968207551426526" k="295046.6169804358" class1="17" class2="33"/>
-<Bond length="0.10968207551426526" k="295046.6169804358" class1="17" class2="34"/>
-<Bond length="0.13769965673158013" k="350155.32734256436" class1="18" class2="19"/>
-<Bond length="0.14239910645593554" k="236954.7779603677" class1="18" class2="21"/>
-<Bond length="0.14040346349188373" k="290675.9943500282" class1="19" class2="20"/>
-<Bond length="0.1084526136401619" k="332788.9040241763" class1="19" class2="35"/>
-<Bond length="0.21652967675118645" k="65752.2685533569" class1="0" class2="2"/>
-<Bond length="0.21652967675118645" k="65752.2685533569" class1="0" class2="3"/>
-<Bond length="0.2367308754593913" k="35097.51844577419" class1="0" class2="4"/>
-<Bond length="0.24637183735463966" k="22766.286083202882" class1="1" class2="5"/>
-<Bond length="0.2552484693842637" k="33308.821775625285" class1="1" class2="20"/>
-<Bond length="0.21652967675118645" k="65752.2685533569" class1="2" class2="3"/>
-<Bond length="0.2367308754593913" k="35097.51844577419" class1="2" class2="4"/>
-<Bond length="0.2367308754593913" k="35097.51844577419" class1="3" class2="4"/>
-<Bond length="0.24424950724834102" k="33413.30187459911" class1="4" class2="6"/>
-<Bond length="0.2137728474468069" k="14026.150021973126" class1="4" class2="22"/>
-<Bond length="0.24235320460628298" k="29359.23491262911" class1="4" class2="9"/>
-<Bond length="0.25380961300478017" k="37919.66966642074" class1="4" class2="19"/>
-<Bond length="0.24317848563613786" k="49748.88547849213" class1="5" class2="20"/>
-<Bond length="0.23691569131052775" k="62595.152719528414" class1="5" class2="7"/>
-<Bond length="0.2404062775308595" k="36240.16958437524" class1="5" class2="8"/>
-<Bond length="0.21616921612132547" k="16590.049023226384" class1="6" class2="22"/>
-<Bond length="0.24155207989996136" k="44506.468345945024" class1="6" class2="9"/>
-<Bond length="0.22173066563125332" k="94729.48975647744" class1="7" class2="8"/>
-<Bond length="0.23348443062234248" k="57554.66560831616" class1="8" class2="10"/>
-<Bond length="0.2409996256628092" k="33046.49277275733" class1="8" class2="20"/>
-<Bond length="0.2508615762103375" k="19610.01547957706" class1="9" class2="11"/>
-<Bond length="0.2403603662334068" k="50325.95005177289" class1="9" class2="21"/>
-<Bond length="0.23893622663484204" k="45529.13501093602" class1="9" class2="19"/>
-<Bond length="0.24561151969819398" k="40743.13462124213" class1="10" class2="20"/>
-<Bond length="0.25043517668197823" k="21505.46413599935" class1="10" class2="12"/>
-<Bond length="0.2143215696888813" k="17904.811736016643" class1="10" class2="23"/>
-<Bond length="0.2143215696888813" k="17904.811736016643" class1="10" class2="24"/>
-<Bond length="0.24191336629679144" k="47097.831805307374" class1="10" class2="14"/>
-<Bond length="0.2449311721801657" k="42402.55603279804" class1="10" class2="18"/>
-<Bond length="0.2554238649411517" k="15377.298529872323" class1="11" class2="21"/>
-<Bond length="0.24943515144206752" k="32195.329208063562" class1="11" class2="13"/>
-<Bond length="0.21638649819857225" k="11503.954947145208" class1="11" class2="25"/>
-<Bond length="0.21638649819857225" k="11503.954947145208" class1="11" class2="26"/>
-<Bond length="0.21637698760602225" k="11672.974219363094" class1="12" class2="23"/>
-<Bond length="0.21637698760602225" k="11672.974219363094" class1="12" class2="24"/>
-<Bond length="0.2445664336412628" k="33256.01522279772" class1="12" class2="14"/>
-<Bond length="0.21627463620927637" k="11491.033607839858" class1="12" class2="27"/>
-<Bond length="0.21627463620927637" k="11491.033607839858" class1="12" class2="28"/>
-<Bond length="0.2146925734975977" k="13360.26816805869" class1="13" class2="25"/>
-<Bond length="0.2146925734975977" k="13360.26816805869" class1="13" class2="26"/>
-<Bond length="0.2466018129470507" k="3736.7354885250256" class1="13" class2="15"/>
-<Bond length="0.24530456727951677" k="26062.586271548935" class1="13" class2="21"/>
-<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="27"/>
-<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="28"/>
-<Bond length="0.24506286921679699" k="33221.952059765485" class1="14" class2="16"/>
-<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="29"/>
-<Bond length="0.20904668083340297" k="23140.94379657196" class1="14" class2="30"/>
-<Bond length="0.24341685186846426" k="45678.9365063201" class1="14" class2="18"/>
-<Bond length="0.24530456727951677" k="26062.586271548935" class1="15" class2="21"/>
-<Bond length="0.2482899688867673" k="31024.378168591185" class1="15" class2="17"/>
-<Bond length="0.21482896649717576" k="13667.387394240935" class1="15" class2="31"/>
-<Bond length="0.21482896649717576" k="13667.387394240935" class1="15" class2="32"/>
-<Bond length="0.2161210191868845" k="10740.514701412663" class1="16" class2="29"/>
-<Bond length="0.2161210191868845" k="10740.514701412663" class1="16" class2="30"/>
-<Bond length="0.25071186281720664" k="21767.12177986897" class1="16" class2="18"/>
-<Bond length="0.21588768954068127" k="12305.051141155052" class1="16" class2="33"/>
-<Bond length="0.21588768954068127" k="12305.051141155052" class1="16" class2="34"/>
-<Bond length="0.2166014429827969" k="11757.510013757139" class1="17" class2="31"/>
-<Bond length="0.2166014429827969" k="11757.510013757139" class1="17" class2="32"/>
-<Bond length="0.2501622513015905" k="13468.893552980422" class1="17" class2="19"/>
-<Bond length="0.25504206857818595" k="17020.18071746364" class1="17" class2="21"/>
-<Bond length="0.2145767289449851" k="15224.635392491049" class1="18" class2="33"/>
-<Bond length="0.2145767289449851" k="15224.635392491049" class1="18" class2="34"/>
-<Bond length="0.24352193235081798" k="52903.72109806267" class1="18" class2="20"/>
-<Bond length="0.21177124922411472" k="8020.984179537393" class1="18" class2="35"/>
-<Bond length="0.24207073997933107" k="54060.175707486436" class1="19" class2="21"/>
-<Bond length="0.21560948327565438" k="10601.247393547372" class1="20" class2="35"/>
-<Bond length="0.17462080461979723" k="13702.455171858066" class1="23" class2="24"/>
-<Bond length="0.17661650584198943" k="13363.67976471447" class1="25" class2="26"/>
-<Bond length="0.17685797959042412" k="13047.147646234267" class1="27" class2="28"/>
-<Bond length="0.17685797959042412" k="13047.147646234267" class1="29" class2="30"/>
-<Bond length="0.1767871797367549" k="13194.049029061343" class1="31" class2="32"/>
-<Bond length="0.17560269028929812" k="13761.299394180302" class1="33" class2="34"/>
+<Bond length="0.13469356407442745" k="248703.9453450384" class1="0" class2="1"/>
+<Bond length="0.13469356407442745" k="248703.9453450384" class1="1" class2="2"/>
+<Bond length="0.13469356407442745" k="248703.9453450384" class1="1" class2="3"/>
+<Bond length="0.15089307265750462" k="218107.80263997507" class1="1" class2="4"/>
+<Bond length="0.13479954466568161" k="452535.82256476" class1="4" class2="5"/>
+<Bond length="0.1442415502989459" k="235789.03321713425" class1="4" class2="20"/>
+<Bond length="0.14564591082883702" k="214143.29026495383" class1="5" class2="6"/>
+<Bond length="0.10814511275621547" k="337583.31142760173" class1="5" class2="22"/>
+<Bond length="0.12065331189134898" k="697180.528418064" class1="6" class2="7"/>
+<Bond length="0.13738032210105275" k="170745.83724304655" class1="6" class2="8"/>
+<Bond length="0.13688031490221972" k="246197.31037783858" class1="8" class2="9"/>
+<Bond length="0.13896874772055998" k="302717.1682177711" class1="9" class2="10"/>
+<Bond length="0.14002870254626087" k="278750.2331485008" class1="9" class2="20"/>
+<Bond length="0.15105020854333961" k="198343.77388770523" class1="10" class2="11"/>
+<Bond length="0.140971231725981" k="267337.8377080386" class1="10" class2="21"/>
+<Bond length="0.1524083899867472" k="188833.91597902204" class1="11" class2="12"/>
+<Bond length="0.10957700046070398" k="298261.2005884687" class1="11" class2="23"/>
+<Bond length="0.10957700046070398" k="298261.2005884687" class1="11" class2="24"/>
+<Bond length="0.15195279246806304" k="191040.96419846595" class1="12" class2="13"/>
+<Bond length="0.10953626718429424" k="299519.34500515234" class1="12" class2="25"/>
+<Bond length="0.10953626718429424" k="299519.34500515234" class1="12" class2="26"/>
+<Bond length="0.14540284161875516" k="204863.64799699787" class1="13" class2="14"/>
+<Bond length="0.10990907747815233" k="289948.72500367067" class1="13" class2="27"/>
+<Bond length="0.10990907747815233" k="289948.72500367067" class1="13" class2="28"/>
+<Bond length="0.14540284161875516" k="204863.64799699787" class1="14" class2="15"/>
+<Bond length="0.13825047971094792" k="275239.1942746975" class1="14" class2="21"/>
+<Bond length="0.15197197918433358" k="190732.3801908442" class1="15" class2="16"/>
+<Bond length="0.10990907747815233" k="289948.72500367067" class1="15" class2="29"/>
+<Bond length="0.10990907747815233" k="289948.72500367067" class1="15" class2="30"/>
+<Bond length="0.15233937621320007" k="188446.58284862092" class1="16" class2="17"/>
+<Bond length="0.10954484075537119" k="299166.43273590214" class1="16" class2="31"/>
+<Bond length="0.10954484075537119" k="299166.43273590214" class1="16" class2="32"/>
+<Bond length="0.15125045314560479" k="200880.19205211668" class1="17" class2="18"/>
+<Bond length="0.10968207551426526" k="295045.4587180927" class1="17" class2="33"/>
+<Bond length="0.10968207551426526" k="295045.4587180927" class1="17" class2="34"/>
+<Bond length="0.13769965673158016" k="350153.8773233665" class1="18" class2="19"/>
+<Bond length="0.14239910645593554" k="236942.8900502614" class1="18" class2="21"/>
+<Bond length="0.14040346349188373" k="290651.1618865422" class1="19" class2="20"/>
+<Bond length="0.1084526136401619" k="332797.3935863543" class1="19" class2="35"/>
 </HarmonicBondForce>
 <HarmonicAngleForce>
-<Angle k="636.4040553561965" angle="1.8672649914285966" class1="0" class2="1" class3="2"/>
-<Angle k="636.4040553561965" angle="1.8672649914285966" class1="0" class2="1" class3="3"/>
-<Angle k="534.1866551637136" angle="1.952201128639467" class1="0" class2="1" class3="4"/>
-<Angle k="409.71521276491893" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
-<Angle k="136.79997336432282" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
-<Angle k="636.4040553561965" angle="1.8672649914285966" class1="2" class2="1" class3="3"/>
-<Angle k="534.1866551637136" angle="1.952201128639467" class1="2" class2="1" class3="4"/>
-<Angle k="534.1866551637136" angle="1.952201128639467" class1="3" class2="1" class3="4"/>
-<Angle k="596.7728846990148" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
-<Angle k="251.3358417912241" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
-<Angle k="548.0435606806428" angle="2.0415366387444425" class1="4" class2="20" class3="9"/>
-<Angle k="678.2808594294862" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
-<Angle k="94.20048681133204" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
-<Angle k="247.22531384335034" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
-<Angle k="112.52203837797829" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
-<Angle k="212.3218943278685" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
-<Angle k="474.6411980162593" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
-<Angle k="769.6873434595309" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
-<Angle k="658.266039158154" angle="2.0184198324929117" class1="8" class2="9" class3="10"/>
-<Angle k="438.2022748632177" angle="2.1116327525982004" class1="8" class2="9" class3="20"/>
-<Angle k="316.6019984663359" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
-<Angle k="401.91551591572727" angle="2.0650887323276095" class1="9" class2="10" class3="21"/>
-<Angle k="303.51197633594205" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
-<Angle k="103.31247281062609" angle="2.153132674384378" class1="10" class2="9" class3="20"/>
-<Angle k="400.48689576331174" angle="1.9413453751779068" class1="10" class2="11" class3="12"/>
-<Angle k="295.20302696156057" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
-<Angle k="295.20302696156057" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
-<Angle k="598.9610350044281" angle="2.0957777004398204" class1="10" class2="21" class3="14"/>
-<Angle k="105.78200812731957" angle="2.087698323200135" class1="10" class2="21" class3="18"/>
-<Angle k="422.37009093288634" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
-<Angle k="604.8643424849223" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
-<Angle k="354.7085988438403" angle="1.9255116484664125" class1="11" class2="12" class3="25"/>
-<Angle k="354.7085988438403" angle="1.9255116484664125" class1="11" class2="12" class3="26"/>
-<Angle k="347.52226423238415" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
-<Angle k="347.52226423238415" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
-<Angle k="522.2572264706107" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
-<Angle k="352.21015548084887" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
-<Angle k="352.21015548084887" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
-<Angle k="342.2696819227702" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
-<Angle k="342.2696819227702" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
-<Angle k="627.0430471983619" angle="2.0243821725347932" class1="13" class2="14" class3="15"/>
-<Angle k="333.3950317013976" angle="2.0891509949808236" class1="13" class2="14" class3="21"/>
-<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
-<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
-<Angle k="513.6010207608534" angle="1.9368432495236967" class1="14" class2="15" class3="16"/>
-<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
-<Angle k="361.6415181374037" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
-<Angle k="618.3762057433295" angle="2.09951489979246" class1="14" class2="21" class3="18"/>
-<Angle k="333.3950317013976" angle="2.0891509949808236" class1="15" class2="14" class3="21"/>
-<Angle k="614.3379233697891" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
-<Angle k="343.4470607410886" angle="1.9092775396461912" class1="15" class2="16" class3="31"/>
-<Angle k="343.4470607410886" angle="1.9092775396461912" class1="15" class2="16" class3="32"/>
-<Angle k="358.82189452864463" angle="1.9232796805236194" class1="16" class2="15" class3="29"/>
-<Angle k="358.82189452864463" angle="1.9232796805236194" class1="16" class2="15" class3="30"/>
-<Angle k="373.6632811649154" angle="1.9433159713266135" class1="16" class2="17" class3="18"/>
-<Angle k="353.34730540873824" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
-<Angle k="353.34730540873824" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
-<Angle k="361.5158176709999" angle="1.9292385966058512" class1="17" class2="16" class3="31"/>
-<Angle k="361.5158176709999" angle="1.9292385966058512" class1="17" class2="16" class3="32"/>
-<Angle k="536.6295412302601" angle="2.092071456839349" class1="17" class2="18" class3="19"/>
-<Angle k="419.4058971998923" angle="2.1039194702972392" class1="17" class2="18" class3="21"/>
-<Angle k="299.5772155612874" angle="1.913085372946379" class1="18" class2="17" class3="33"/>
-<Angle k="299.5772155612874" angle="1.913085372946379" class1="18" class2="17" class3="34"/>
-<Angle k="231.37386417830206" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
-<Angle k="326.0736683080835" angle="2.0633536847112035" class1="18" class2="19" class3="35"/>
-<Angle k="372.4825926009225" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
-<Angle k="193.55670775969207" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
-<Angle k="262.1432565874291" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
-<Angle k="270.96482284955744" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
-<Angle k="261.9334015695606" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
-<Angle k="261.9334015695606" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
-<Angle k="267.4878637894604" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
-<Angle k="273.5497074794414" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
+<Angle k="636.4804817299603" angle="1.8672649914285964" class1="0" class2="1" class3="2"/>
+<Angle k="636.4804817299603" angle="1.8672649914285964" class1="0" class2="1" class3="3"/>
+<Angle k="534.290655553001" angle="1.9522011286394667" class1="0" class2="1" class3="4"/>
+<Angle k="409.6321345829706" angle="2.0779843356076713" class1="1" class2="4" class3="5"/>
+<Angle k="136.76371933185294" angle="2.0894254765254674" class1="1" class2="4" class3="20"/>
+<Angle k="636.4804817299603" angle="1.8672649914285964" class1="2" class2="1" class3="3"/>
+<Angle k="534.290655553001" angle="1.9522011286394667" class1="2" class2="1" class3="4"/>
+<Angle k="534.290655553001" angle="1.9522011286394667" class1="3" class2="1" class3="4"/>
+<Angle k="596.8472777036479" angle="2.113354999390225" class1="4" class2="5" class3="6"/>
+<Angle k="251.61065898422217" angle="2.144840093016642" class1="4" class2="5" class3="22"/>
+<Angle k="548.1470754043436" angle="2.041536638744443" class1="4" class2="20" class3="9"/>
+<Angle k="678.3830167308253" angle="2.2019526124875846" class1="4" class2="20" class3="19"/>
+<Angle k="94.02999980091879" angle="2.11577548771511" class1="5" class2="4" class3="20"/>
+<Angle k="247.191514376024" angle="2.1886452508343495" class1="5" class2="6" class3="7"/>
+<Angle k="112.56240276924304" angle="2.0292152443370686" class1="5" class2="6" class3="8"/>
+<Angle k="212.31327143905733" angle="2.0249902145381" class1="6" class2="5" class3="22"/>
+<Angle k="474.46099327199823" angle="2.15483949130777" class1="6" class2="8" class3="9"/>
+<Angle k="769.676332703852" angle="2.0653247966870745" class1="7" class2="6" class3="8"/>
+<Angle k="658.2136081991305" angle="2.0184198324929112" class1="8" class2="9" class3="10"/>
+<Angle k="438.18883322941474" angle="2.111632752598201" class1="8" class2="9" class3="20"/>
+<Angle k="316.5724231524982" angle="2.089226306975087" class1="9" class2="10" class3="11"/>
+<Angle k="402.04481311932557" angle="2.065088732327609" class1="9" class2="10" class3="21"/>
+<Angle k="303.5391612957046" angle="2.0396954468002875" class1="9" class2="20" class3="19"/>
+<Angle k="103.2772701648923" angle="2.1531326743843784" class1="10" class2="9" class3="20"/>
+<Angle k="400.32105993993684" angle="1.9413453751779066" class1="10" class2="11" class3="12"/>
+<Angle k="295.1281875690809" angle="1.913070411693251" class1="10" class2="11" class3="23"/>
+<Angle k="295.1281875690809" angle="1.913070411693251" class1="10" class2="11" class3="24"/>
+<Angle k="598.8069440248596" angle="2.0957777004398195" class1="10" class2="21" class3="14"/>
+<Angle k="105.5593532380269" angle="2.0876983232001356" class1="10" class2="21" class3="18"/>
+<Angle k="422.4287055294135" angle="2.128869182617119" class1="11" class2="10" class3="21"/>
+<Angle k="605.181225691815" angle="1.9212024194648585" class1="11" class2="12" class3="13"/>
+<Angle k="354.7460790674407" angle="1.9255116484664123" class1="11" class2="12" class3="25"/>
+<Angle k="354.7460790674407" angle="1.9255116484664123" class1="11" class2="12" class3="26"/>
+<Angle k="347.36882397840907" angle="1.9249576627148293" class1="12" class2="11" class3="23"/>
+<Angle k="347.36882397840907" angle="1.9249576627148293" class1="12" class2="11" class3="24"/>
+<Angle k="522.0866097824091" angle="1.9311481727000421" class1="12" class2="13" class3="14"/>
+<Angle k="351.7091048895161" angle="1.9256320407195773" class1="12" class2="13" class3="27"/>
+<Angle k="351.7091048895161" angle="1.9256320407195773" class1="12" class2="13" class3="28"/>
+<Angle k="342.4073585844633" angle="1.9077297675423202" class1="13" class2="12" class3="25"/>
+<Angle k="342.4073585844633" angle="1.9077297675423202" class1="13" class2="12" class3="26"/>
+<Angle k="627.3214666138175" angle="2.0243821725347937" class1="13" class2="14" class3="15"/>
+<Angle k="333.64374542717064" angle="2.089150994980823" class1="13" class2="14" class3="21"/>
+<Angle k="360.9958703826568" angle="1.9048139765030223" class1="14" class2="13" class3="27"/>
+<Angle k="360.9958703826568" angle="1.9048139765030223" class1="14" class2="13" class3="28"/>
+<Angle k="513.3950781825669" angle="1.936843249523697" class1="14" class2="15" class3="16"/>
+<Angle k="360.9958703826568" angle="1.9048139765030223" class1="14" class2="15" class3="29"/>
+<Angle k="360.9958703826568" angle="1.9048139765030223" class1="14" class2="15" class3="30"/>
+<Angle k="618.2375816584317" angle="2.0995148997924606" class1="14" class2="21" class3="18"/>
+<Angle k="333.64374542717064" angle="2.089150994980823" class1="15" class2="14" class3="21"/>
+<Angle k="614.8551732814161" angle="1.9085936244251438" class1="15" class2="16" class3="17"/>
+<Angle k="343.65093323134596" angle="1.909277539646191" class1="15" class2="16" class3="31"/>
+<Angle k="343.65093323134596" angle="1.909277539646191" class1="15" class2="16" class3="32"/>
+<Angle k="358.1941042113908" angle="1.9232796805236196" class1="16" class2="15" class3="29"/>
+<Angle k="358.1941042113908" angle="1.9232796805236196" class1="16" class2="15" class3="30"/>
+<Angle k="373.4770793718959" angle="1.943315971326614" class1="16" class2="17" class3="18"/>
+<Angle k="353.18452040687134" angle="1.917967793518872" class1="16" class2="17" class3="33"/>
+<Angle k="353.18452040687134" angle="1.917967793518872" class1="16" class2="17" class3="34"/>
+<Angle k="361.5788999048821" angle="1.9292385966058516" class1="17" class2="16" class3="31"/>
+<Angle k="361.5788999048821" angle="1.9292385966058516" class1="17" class2="16" class3="32"/>
+<Angle k="536.6552019643872" angle="2.0920714568393497" class1="17" class2="18" class3="19"/>
+<Angle k="419.47523569788035" angle="2.103919470297239" class1="17" class2="18" class3="21"/>
+<Angle k="299.4389954353236" angle="1.9130853729463788" class1="18" class2="17" class3="33"/>
+<Angle k="299.4389954353236" angle="1.9130853729463788" class1="18" class2="17" class3="34"/>
+<Angle k="231.40391829139614" angle="2.133521957831091" class1="18" class2="19" class3="20"/>
+<Angle k="325.843429352764" angle="2.063353684711203" class1="18" class2="19" class3="35"/>
+<Angle k="372.64148870806133" angle="2.087085755602085" class1="19" class2="18" class3="21"/>
+<Angle k="193.62594542902988" angle="2.0862706667820365" class1="20" class2="19" class3="35"/>
+<Angle k="262.128998981701" angle="1.843944714687622" class1="23" class2="11" class3="24"/>
+<Angle k="271.002401138116" angle="1.875405376528391" class1="25" class2="12" class3="26"/>
+<Angle k="261.9038079863788" angle="1.8698850099088045" class1="27" class2="13" class3="28"/>
+<Angle k="261.9038079863788" angle="1.8698850099088045" class1="29" class2="15" class3="30"/>
+<Angle k="267.5090264252675" angle="1.87782747624632" class1="31" class2="16" class3="32"/>
+<Angle k="273.4972071699075" angle="1.856283699222398" class1="33" class2="17" class3="34"/>
 </HarmonicAngleForce>
+<AmoebaUreyBradleyForce>
+<UreyBradley k="32877.31609818407" d="0.2165296767511864" class1="0" class2="1" class3="2"/>
+<UreyBradley k="32877.31609818407" d="0.2165296767511864" class1="0" class2="1" class3="3"/>
+<UreyBradley k="17560.28977398548" d="0.2367308754593913" class1="0" class2="1" class3="4"/>
+<UreyBradley k="11384.980183730064" d="0.24637183735463966" class1="1" class2="4" class3="5"/>
+<UreyBradley k="16652.7276754137" d="0.25524846938426365" class1="1" class2="4" class3="20"/>
+<UreyBradley k="32877.31609818407" d="0.2165296767511864" class1="2" class2="1" class3="3"/>
+<UreyBradley k="17560.28977398548" d="0.2367308754593913" class1="2" class2="1" class3="4"/>
+<UreyBradley k="17560.28977398548" d="0.2367308754593913" class1="3" class2="1" class3="4"/>
+<UreyBradley k="16701.728284718643" d="0.24424950724834096" class1="4" class2="5" class3="6"/>
+<UreyBradley k="7014.028715411655" d="0.2137728474468069" class1="4" class2="5" class3="22"/>
+<UreyBradley k="14675.577684928245" d="0.24235320460628296" class1="4" class2="20" class3="9"/>
+<UreyBradley k="18951.489105943223" d="0.25380961300478017" class1="4" class2="20" class3="19"/>
+<UreyBradley k="24873.407660034634" d="0.24317848563613784" class1="5" class2="4" class3="20"/>
+<UreyBradley k="31301.88914073426" d="0.23691569131052767" class1="5" class2="6" class3="7"/>
+<UreyBradley k="18115.784739075214" d="0.24040627753085944" class1="5" class2="6" class3="8"/>
+<UreyBradley k="8302.475585581715" d="0.2161692161213254" class1="6" class2="5" class3="22"/>
+<UreyBradley k="22258.281816929924" d="0.24155207989996136" class1="6" class2="8" class3="9"/>
+<UreyBradley k="47364.12405226418" d="0.22173066563125332" class1="7" class2="6" class3="8"/>
+<UreyBradley k="28772.392519994213" d="0.23348443062234245" class1="8" class2="9" class3="10"/>
+<UreyBradley k="16525.210191717746" d="0.24099962566280914" class1="8" class2="9" class3="20"/>
+<UreyBradley k="9806.59589186246" d="0.25086157621033756" class1="9" class2="10" class3="11"/>
+<UreyBradley k="25156.95429348868" d="0.24036036623340684" class1="9" class2="10" class3="21"/>
+<UreyBradley k="22757.029286082856" d="0.23893622663484196" class1="9" class2="20" class3="19"/>
+<UreyBradley k="20374.15237732561" d="0.24561151969819403" class1="10" class2="9" class3="20"/>
+<UreyBradley k="10750.239731916921" d="0.2504351766819783" class1="10" class2="11" class3="12"/>
+<UreyBradley k="8948.66848970909" d="0.2143215696888813" class1="10" class2="11" class3="23"/>
+<UreyBradley k="8948.66848970909" d="0.2143215696888813" class1="10" class2="11" class3="24"/>
+<UreyBradley k="23562.31371387597" d="0.2419133662967915" class1="10" class2="21" class3="14"/>
+<UreyBradley k="21205.222218193707" d="0.24493117218016575" class1="10" class2="21" class3="18"/>
+<UreyBradley k="7688.2668469739765" d="0.2554238649411517" class1="11" class2="10" class3="21"/>
+<UreyBradley k="16069.199381626207" d="0.24943515144206754" class1="11" class2="12" class3="13"/>
+<UreyBradley k="5759.471584747297" d="0.21638649819857228" class1="11" class2="12" class3="25"/>
+<UreyBradley k="5759.471584747297" d="0.21638649819857228" class1="11" class2="12" class3="26"/>
+<UreyBradley k="5840.925587694062" d="0.2163769876060223" class1="12" class2="11" class3="23"/>
+<UreyBradley k="5840.925587694062" d="0.2163769876060223" class1="12" class2="11" class3="24"/>
+<UreyBradley k="16637.770943031388" d="0.2445664336412628" class1="12" class2="13" class3="14"/>
+<UreyBradley k="5718.589866218549" d="0.21627463620927637" class1="12" class2="13" class3="27"/>
+<UreyBradley k="5718.589866218549" d="0.21627463620927637" class1="12" class2="13" class3="28"/>
+<UreyBradley k="6686.957528389902" d="0.21469257349759774" class1="13" class2="12" class3="25"/>
+<UreyBradley k="6686.957528389902" d="0.21469257349759774" class1="13" class2="12" class3="26"/>
+<UreyBradley k="1855.499560374056" d="0.24660181294705075" class1="13" class2="14" class3="15"/>
+<UreyBradley k="13037.766721121381" d="0.24530456727951677" class1="13" class2="14" class3="21"/>
+<UreyBradley k="11530.670798870085" d="0.20904668083340297" class1="14" class2="13" class3="27"/>
+<UreyBradley k="11530.670798870085" d="0.20904668083340297" class1="14" class2="13" class3="28"/>
+<UreyBradley k="16625.4369996374" d="0.245062869216797" class1="14" class2="15" class3="16"/>
+<UreyBradley k="11530.670798870085" d="0.20904668083340297" class1="14" class2="15" class3="29"/>
+<UreyBradley k="11530.670798870085" d="0.20904668083340297" class1="14" class2="15" class3="30"/>
+<UreyBradley k="22851.802454914654" d="0.24341685186846435" class1="14" class2="21" class3="18"/>
+<UreyBradley k="13037.766721121381" d="0.24530456727951677" class1="15" class2="14" class3="21"/>
+<UreyBradley k="15480.667376263445" d="0.2482899688867673" class1="15" class2="16" class3="17"/>
+<UreyBradley k="6836.335294942607" d="0.21482896649717576" class1="15" class2="16" class3="31"/>
+<UreyBradley k="6836.335294942607" d="0.21482896649717576" class1="15" class2="16" class3="32"/>
+<UreyBradley k="5326.879434341324" d="0.21612101918688453" class1="16" class2="15" class3="29"/>
+<UreyBradley k="5326.879434341324" d="0.21612101918688453" class1="16" class2="15" class3="30"/>
+<UreyBradley k="10879.252515904685" d="0.25071186281720664" class1="16" class2="17" class3="18"/>
+<UreyBradley k="6153.781365461585" d="0.21588768954068122" class1="16" class2="17" class3="33"/>
+<UreyBradley k="6153.781365461585" d="0.21588768954068122" class1="16" class2="17" class3="34"/>
+<UreyBradley k="5886.084500871855" d="0.2166014429827969" class1="17" class2="16" class3="31"/>
+<UreyBradley k="5886.084500871855" d="0.2166014429827969" class1="17" class2="16" class3="32"/>
+<UreyBradley k="6728.83417082292" d="0.2501622513015906" class1="17" class2="18" class3="19"/>
+<UreyBradley k="8510.5777119919" d="0.25504206857818595" class1="17" class2="18" class3="21"/>
+<UreyBradley k="7601.554023844051" d="0.2145767289449851" class1="18" class2="17" class3="33"/>
+<UreyBradley k="7601.554023844051" d="0.2145767289449851" class1="18" class2="17" class3="34"/>
+<UreyBradley k="26455.30419840847" d="0.24352193235081804" class1="18" class2="19" class3="20"/>
+<UreyBradley k="4013.7529440352346" d="0.21177124922411472" class1="18" class2="19" class3="35"/>
+<UreyBradley k="27030.152408864284" d="0.24207073997933107" class1="19" class2="18" class3="21"/>
+<UreyBradley k="5299.641662504738" d="0.21560948327565438" class1="20" class2="19" class3="35"/>
+<UreyBradley k="6852.276617402795" d="0.17462080461979723" class1="23" class2="11" class3="24"/>
+<UreyBradley k="6682.912621737013" d="0.1766165058419895" class1="25" class2="12" class3="26"/>
+<UreyBradley k="6535.41126521401" d="0.17685797959042412" class1="27" class2="13" class3="28"/>
+<UreyBradley k="6535.41126521401" d="0.17685797959042412" class1="29" class2="15" class3="30"/>
+<UreyBradley k="6597.107512686989" d="0.1767871797367549" class1="31" class2="16" class3="32"/>
+<UreyBradley k="6880.994623083163" d="0.17560269028929812" class1="33" class2="17" class3="34"/>
+</AmoebaUreyBradleyForce>
 <PeriodicTorsionForce ordering="charmm">
-<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
-<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="14.987254051360019" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
-<Proper k1="0" k2="24.161434815972157" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="13.840603003560435" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
-<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
-<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
-<Proper k1="1.039711494008e-06" k2="-1.820903897188" k3="-1.44323646854" k4="8.663620559958e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
-<Proper k1="1.184598345459e-06" k2="1.227213305852e-06" k3="-0.9391055307582" k4="7.229677169388e-07" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
-<Proper k1="0" k2="62.76434875493169" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
-<Proper k1="0" k2="43.05716767703306" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
-<Proper k1="0" k2="14.099717731353625" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="8"/>
-<Proper k1="0" k2="32.11723285789512" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="9" class4="10"/>
-<Proper k1="0" k2="20.14832280505608" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="6.238769556072177" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="21.396325246806697" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
-<Proper k1="0" k2="7.412883360745509" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
-<Proper k1="0" k2="11.037061048422125" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="19.66341156914107" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
-<Proper k1="0" k2="35.84782905877354" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="13.246741161068709" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
-<Proper k1="0" k2="19.718641725188782" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="6" class3="5" class4="22"/>
-<Proper k1="0" k2="26.89869959283934" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
-<Proper k1="0" k2="19.564641024974517" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="13.308366006520128" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="19.33552535369704" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="21.979979166611848" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="18"/>
-<Proper k1="0" k2="10.902709171624208" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="20" class3="19" class4="35"/>
-<Proper k1="0" k2="5.143393889179049" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
-<Proper k1="0" k2="5.867161518059558" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="14" class4="13"/>
-<Proper k1="0" k2="37.44189566323711" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="36.29213254589665" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="25.377563782046575" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="9" class4="20"/>
-<Proper k1="0" k2="18.021356889874767" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
-<Proper k1="0" k2="26.66907635878022" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
-<Proper k1="0" k2="4.234848872539599" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="12" class2="11" class3="10" class4="21"/>
-<Proper k1="0" k2="22.933886285402842" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="17"/>
-<Proper k1="0" k2="21.533965765355514" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="14" class2="21" class3="18" class4="19"/>
-<Proper k1="0" k2="2.644886174029585" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
-<Proper k1="0" k2="22.668407575421234" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
-<Proper k1="0" k2="20.10782046460023" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
-<Proper k1="0" k2="21.470227795530203" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
-<Proper k1="0" k2="3.4820300437332317" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="19" class3="18" class4="21"/>
-<Proper k1="0" k2="28.560156766840628" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="14.9756944342544" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="7.137604551980973e-32" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="2.7780764294083136e-09" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="6"/>
+<Proper k1="0" k2="2.0656820800335975e-33" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="4" class3="5" class4="22"/>
+<Proper k1="0" k2="24.140736141773434" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="13.84132140262081" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="1" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="21.39678883793865" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="9"/>
+<Proper k1="0" k2="7.406104967370744" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="4" class3="20" class4="19"/>
+<Proper k1="0" k2="62.766853176883025" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="43.05667764382261" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="4" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="35.84990015660589" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="7"/>
+<Proper k1="0" k2="19.712889695756232" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="22" class2="5" class3="6" class4="8"/>
+<Proper k1="0" k2="11.03459362825888" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="5" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="13.239853302446894" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="7" class2="6" class3="8" class4="9"/>
+<Proper k1="0" k2="19.669538981975908" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="10"/>
+<Proper k1="0" k2="3.196242450783075e-14" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="6" class2="8" class3="9" class4="20"/>
+<Proper k1="0" k2="26.91435058270231" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="19.575744602003116" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="25.409311817406643" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="11"/>
+<Proper k1="0" k2="21.47093933200793" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="20" class2="9" class3="10" class4="21"/>
+<Proper k1="0" k2="14.094250688457285" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="13.293497887251858" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="8" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="32.11850961018464" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="4"/>
+<Proper k1="0" k2="5.148005227881435" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="10" class2="9" class3="20" class4="19"/>
+<Proper k1="0" k2="4.283513863327017" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="10" class3="11" class4="12"/>
+<Proper k1="0" k2="19.314323861036208" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="3.699827822552674e-22" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="9" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="17.958986134173216" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="14"/>
+<Proper k1="0" k2="26.66030200376212" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="11" class2="10" class3="21" class4="18"/>
+<Proper k1="0" k2="5.91550046868286" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="13" class2="14" class3="21" class4="10"/>
+<Proper k1="0" k2="2.6920167571293896" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="15" class2="14" class3="21" class4="18"/>
+<Proper k1="0" k2="2.642049436786451e-22" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="16" class2="17" class3="18" class4="21"/>
+<Proper k1="0" k2="22.71202621769021" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="20.118602057102418" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="3.493565659048291" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="20"/>
+<Proper k1="0" k2="28.57012085107939" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="21" class2="18" class3="19" class4="35"/>
+<Proper k1="0" k2="37.45555167959392" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="22.90793101426087" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="17" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="36.29027953508967" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="10"/>
+<Proper k1="0" k2="21.541533587824205" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="19" class2="18" class3="21" class4="14"/>
+<Proper k1="0" k2="20.1422646064904" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="21.969482680771577" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="18" class2="19" class3="20" class4="9"/>
+<Proper k1="0" k2="6.231766796078931" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="4"/>
+<Proper k1="0" k2="10.8931287993517" k3="0" k4="0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793" class1="35" class2="19" class3="20" class4="9"/>
+<Proper k1="7.172334038646e-07" k2="-1.820903942021" k3="-1.307090808688" k4="1.221648305697e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="5"/>
+<Proper k1="1.330139502605e-06" k2="1.317482396616e-06" k3="-0.9391060087808" k4="1.045454905589e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="0" class2="1" class3="4" class4="20"/>
+<Proper k1="7.172334038646e-07" k2="-1.820903942021" k3="-1.307090808688" k4="1.221648305697e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="5"/>
+<Proper k1="1.330139502605e-06" k2="1.317482396616e-06" k3="-0.9391060087808" k4="1.045454905589e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="2" class2="1" class3="4" class4="20"/>
+<Proper k1="7.172334038646e-07" k2="-1.820903942021" k3="-1.307090808688" k4="1.221648305697e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="5"/>
+<Proper k1="1.330139502605e-06" k2="1.317482396616e-06" k3="-0.9391060087808" k4="1.045454905589e-06" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" class1="3" class2="1" class3="4" class4="20"/>
 </PeriodicTorsionForce>
 <RBTorsionForce>
-<Proper c0="20.092" c1="57.654" c2="41.36" c3="0.0" c4="0.0" c5="0.0" class1="10" class2="11" class3="12" class4="13"/>
-<Proper c0="21.248" c1="82.84" c2="80.741" c3="0.0" c4="0.0" c5="0.0" class1="11" class2="12" class3="13" class4="14"/>
-<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="12" class2="13" class3="14" class4="21"/>
-<Proper c0="20.709" c1="80.092" c2="77.438" c3="0.0" c4="0.0" c5="0.0" class1="14" class2="15" class3="16" class4="17"/>
-<Proper c0="17.548" c1="54.416" c2="42.185" c3="0.0" c4="0.0" c5="0.0" class1="15" class2="16" class3="17" class4="18"/>
-<Proper c0="0.0" c1="0.0" c2="0.0" c3="0.0" c4="0.0" c5="0.0" class1="16" class2="15" class3="14" class4="21"/>
+<Proper c0="20.001" c1="57.394" c2="41.173" c3="0" c4="0" c5="0" class1="10" class2="11" class3="12" class4="13"/>
+<Proper c0="21.32" c1="83.121" c2="81.015" c3="0" c4="0" c5="0" class1="11" class2="12" class3="13" class4="14"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0" c4="0" c5="0" class1="12" class2="13" class3="14" class4="21"/>
+<Proper c0="0.0" c1="0.0" c2="0.0" c3="0" c4="0" c5="0" class1="21" class2="14" class3="15" class4="16"/>
+<Proper c0="20.783" c1="80.376" c2="77.713" c3="0" c4="0" c5="0" class1="14" class2="15" class3="16" class4="17"/>
+<Proper c0="17.519" c1="54.326" c2="42.116" c3="0" c4="0" c5="0" class1="15" class2="16" class3="17" class4="18"/>
 </RBTorsionForce>
 <NonbondedForce coulomb14scale="0.8333333333" lj14scale="0.5" combination="amber">
-<Atom charge="-0.25233" epsilon="0.24312107096883973" sigma="0.2978945436309159" type="QUBE_0"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_0"/>
 <Atom charge="0.776573" epsilon="0.3137621288766835" sigma="0.29731865548843023" type="QUBE_1"/>
-<Atom charge="-0.242744" epsilon="0.24178358454706314" sigma="0.29666886791766617" type="QUBE_2"/>
-<Atom charge="-0.251133" epsilon="0.24306111392023294" sigma="0.29783963537987695" type="QUBE_3"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_2"/>
+<Atom charge="-0.248736" epsilon="0.2426562302388524" sigma="0.29746875607798895" type="QUBE_3"/>
 <Atom charge="-0.051181" epsilon="0.3617577618615011" sigma="0.33069182353388327" type="QUBE_4"/>
 <Atom charge="-0.303105" epsilon="0.3772809207194576" sigma="0.34124081032064807" type="QUBE_5"/>
 <Atom charge="0.667684" epsilon="0.313609862900308" sigma="0.2972108117286001" type="QUBE_6"/>
-<Atom charge="-0.56416" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
-<Atom charge="-0.158328" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
+<Atom charge="-0.564160" epsilon="0.48441168075475327" sigma="0.3067932502773743" type="QUBE_7"/>
+<Atom charge="-0.158383" epsilon="0.449919405078532" sigma="0.29031522017548167" type="QUBE_8"/>
 <Atom charge="0.227775" epsilon="0.3436932883429018" sigma="0.318270617002993" type="QUBE_9"/>
 <Atom charge="-0.120378" epsilon="0.36665208454511444" sigma="0.3340299552647392" type="QUBE_10"/>
 <Atom charge="-0.150389" epsilon="0.36713490953834793" sigma="0.3343586499521666" type="QUBE_11"/>
@@ -464,20 +399,20 @@
 <Atom charge="-0.078422" epsilon="0.36713419029681693" sigma="0.33435816039249844" type="QUBE_20"/>
 <Atom charge="0.155012" epsilon="0.34902004099725037" sigma="0.3219500963762515" type="QUBE_21"/>
 <Atom charge="0.167521" epsilon="0.08327170335092592" sigma="0.24047595644632233" type="QUBE_22"/>
-<Atom charge="0.097355" epsilon="0.08581986873989693" sigma="0.24595475122945462" type="QUBE_23"/>
-<Atom charge="0.090775" epsilon="0.08647598481424516" sigma="0.2473587724974695" type="QUBE_24"/>
-<Atom charge="0.091394" epsilon="0.08531979298529052" sigma="0.24488281892469482" type="QUBE_25"/>
-<Atom charge="0.095147" epsilon="0.08315967981655392" sigma="0.24023413144449074" type="QUBE_26"/>
-<Atom charge="0.078988" epsilon="0.08576997248810035" sigma="0.24584786762792243" type="QUBE_27"/>
-<Atom charge="0.061498" epsilon="0.08873187374227504" sigma="0.2521657872781152" type="QUBE_28"/>
-<Atom charge="0.079282" epsilon="0.08564449238725468" sigma="0.24557900513941391" type="QUBE_29"/>
-<Atom charge="0.06061" epsilon="0.08870029760695072" sigma="0.2520987171872303" type="QUBE_30"/>
-<Atom charge="0.093159" epsilon="0.08540001689934773" sigma="0.24505488874102366" type="QUBE_31"/>
-<Atom charge="0.096345" epsilon="0.08324137505423658" sigma="0.24041049492409503" type="QUBE_32"/>
-<Atom charge="0.096629" epsilon="0.08421113158571183" sigma="0.2425006780809266" type="QUBE_33"/>
-<Atom charge="0.087509" epsilon="0.08628029498385563" sigma="0.24694029878997514" type="QUBE_34"/>
-<Atom charge="0.113032" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
-<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site1"/>
-<Atom charge="-0.054117" epsilon="0" sigma="1" type="v-site2"/>
+<Atom charge="0.094065" epsilon="0.08614870266486319" sigma="0.24665875984208874" type="QUBE_23"/>
+<Atom charge="0.094065" epsilon="0.08614870266486319" sigma="0.24665875984208874" type="QUBE_24"/>
+<Atom charge="0.093270" epsilon="0.0842483362791437" sigma="0.2425807464237023" type="QUBE_25"/>
+<Atom charge="0.093270" epsilon="0.0842483362791437" sigma="0.2425807464237023" type="QUBE_26"/>
+<Atom charge="0.070243" epsilon="0.08726653322185535" sigma="0.24904689632052085" type="QUBE_27"/>
+<Atom charge="0.070243" epsilon="0.08726653322185535" sigma="0.24904689632052085" type="QUBE_28"/>
+<Atom charge="0.069946" epsilon="0.08718902543869833" sigma="0.24888155882739335" type="QUBE_29"/>
+<Atom charge="0.069946" epsilon="0.08718902543869833" sigma="0.24888155882739335" type="QUBE_30"/>
+<Atom charge="0.094752" epsilon="0.084329275899709" sigma="0.242754906001391" type="QUBE_31"/>
+<Atom charge="0.094752" epsilon="0.084329275899709" sigma="0.242754906001391" type="QUBE_32"/>
+<Atom charge="0.092069" epsilon="0.08525351116022171" sigma="0.2447406222324233" type="QUBE_33"/>
+<Atom charge="0.092069" epsilon="0.08525351116022171" sigma="0.2447406222324233" type="QUBE_34"/>
+<Atom charge="0.113033" epsilon="0.08866903118426278" sigma="0.2520322990060409" type="QUBE_35"/>
+<Atom charge="-0.054089" epsilon="0" sigma="1" type="v-site1"/>
+<Atom charge="-0.054089" epsilon="0" sigma="1" type="v-site2"/>
 </NonbondedForce>
 </ForceField>


### PR DESCRIPTION
This PR fixes the UB terms in the OpenMM force fields to use the AMOEBA plugin Urey-Bradley handler which does not require virtual bonds between the terminal atoms of each angle. This means the non-bonded exceptions should be as expected for the molecules.

I have also updated the modSem force fields after fixing the way parameters are symmetrised in QUBEKit.